### PR TITLE
fix(workflow): add statuses:write and checks:write permissions (v1.4.4)

### DIFF
--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -28,6 +28,8 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      statuses: write
+      checks: write
 
     steps:
       - name: Checkout repository

--- a/README.md
+++ b/README.md
@@ -224,6 +224,8 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      statuses: write
+      checks: write
 
     steps:
       - name: Checkout repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gemini-review-action"
-version = "1.4.3"
+version = "1.4.4"
 description = "Automated Pull Request code reviews and Issue Triage using Google Gemini"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/starter-examples/gemini-review.yml
+++ b/starter-examples/gemini-review.yml
@@ -28,6 +28,8 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      statuses: write
+      checks: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## 🚀 Overview
- Adds `statuses: write` and `checks: write` permissions to `.github/workflows/gemini-review.yml`, `starter-examples/gemini-review.yml`, and `README.md`.
- Grants `GITHUB_TOKEN` the required REST API permissions to post commit status updates (`POST /repos/{owner}/{repo}/statuses/{commit_id}`) when PR reviews finish.
- Bumps version to `1.4.4`.