### PR TITLE
fix(github): retry transient failures when posting, and two pricing fixes

### DIFF
--- a/gemini_review/__init__.py
+++ b/gemini_review/__init__.py
@@ -17,6 +17,7 @@ from .github import (
     is_inline_suggestion_commit,
     post_commit_status,
     post_review,
+    post_with_retry,
 )
 from .personas import (
     get_persona_prompt,
@@ -64,6 +65,7 @@ from .utils import (
 )
 
 __all__ = [
+    "post_with_retry",
     "Cost",
     "Promo",
     "RATES",

--- a/gemini_review/github.py
+++ b/gemini_review/github.py
@@ -5,6 +5,7 @@ and posting review summaries and inline comments.
 """
 
 import sys
+import time
 from typing import Any
 
 import requests
@@ -165,6 +166,39 @@ def format_pr_comment_history(review_comments: list[dict], issue_comments: list[
     return "\n".join(prompt_parts)
 
 
+# Status codes worth trying again. 5xx and 429 are GitHub saying "not now" rather than "no": the
+# request was well-formed and would have succeeded a moment earlier or later. 4xx others are not
+# retried, because a 403 or 422 will fail identically however many times it is sent.
+RETRYABLE_STATUS = frozenset({429, 500, 502, 503, 504})
+
+# Two retries, ~1s then ~3s. Deliberately small: a review that arrives four minutes late is not
+# much use on a PR someone is waiting to merge, and the job failing loudly is an acceptable
+# outcome. This is for the transient blip, not for riding out an incident.
+POST_RETRIES = 2
+RETRY_BACKOFF_SECONDS = (1, 3)
+
+
+def post_with_retry(url: str, headers: dict, json_payload: dict, timeout: int) -> Any:
+    """POST, retrying only on transient GitHub failures.
+
+    Why this exists: during a GitHub incident the reviewer computed three complete reviews, paid for
+    the tokens, and lost all of them to 503s on the way back. The work was done and thrown away. One
+    retry would have delivered most of it.
+    """
+    response = requests.post(url, headers=headers, json=json_payload, timeout=timeout)
+    for attempt in range(POST_RETRIES):
+        if response.status_code not in RETRYABLE_STATUS:
+            return response
+        delay = RETRY_BACKOFF_SECONDS[min(attempt, len(RETRY_BACKOFF_SECONDS) - 1)]
+        print(
+            f"Notice: GitHub returned {response.status_code}, retrying in {delay}s ({attempt + 1}/{POST_RETRIES})...",
+            file=sys.stderr,
+        )
+        time.sleep(delay)
+        response = requests.post(url, headers=headers, json=json_payload, timeout=timeout)
+    return response
+
+
 def post_review(
     repository: str,
     pr_number: int,
@@ -256,7 +290,7 @@ def post_review(
 
     url = f"https://api.github.com/repos/{repository}/pulls/{pr_number}/reviews"
     print(f"Submitting review to PR #{pr_number} on {repository}...", file=sys.stderr)
-    res = requests.post(url, headers=headers, json=payload, timeout=timeout)
+    res = post_with_retry(url, headers, payload, timeout)
 
     if res.status_code in (200, 201):
         print("Successfully posted PR review atomically.", file=sys.stderr)
@@ -272,7 +306,7 @@ def post_review(
 
     # 1. Post review summary as a single comment on the PR conversation
     issue_url = f"https://api.github.com/repos/{repository}/issues/{pr_number}/comments"
-    res_summary = requests.post(issue_url, headers=headers, json={"body": review_body}, timeout=timeout)
+    res_summary = post_with_retry(issue_url, headers, {"body": review_body}, timeout)
     if res_summary.status_code in (200, 201):
         posted_anything = True
     else:
@@ -285,7 +319,7 @@ def post_review(
         if "start_line" in c:
             c_payload["start_line"] = c["start_line"]
             c_payload["start_side"] = c["start_side"]
-        res_comment = requests.post(comments_url, headers=headers, json=c_payload, timeout=timeout)
+        res_comment = post_with_retry(comments_url, headers, c_payload, timeout)
         if res_comment.status_code in (200, 201):
             posted_anything = True
             print(f"Posted comment {idx + 1}/{len(comments_payload)} successfully.", file=sys.stderr)

--- a/gemini_review/pricing.py
+++ b/gemini_review/pricing.py
@@ -154,13 +154,22 @@ def estimate_cost(usage: dict, model: str | None, config: dict | None = None, to
     output_tokens = max(0, usage.get("candidates_tokens", 0))
 
     uncached_cost = full_price_input / 1e6 * rate.input
-    cached_cost = cached / 1e6 * rate.input * (rate.cache_read or DEFAULT_CACHE_READ_MULTIPLIER)
+    # `is not None` rather than `or`: a rate that legitimately sets cache_read=0.0, which is what a
+    # provider offering free cache reads would look like, is falsy and would silently fall back to 0.1.
+    cache_multiplier = rate.cache_read if rate.cache_read is not None else DEFAULT_CACHE_READ_MULTIPLIER
+    cached_cost = cached / 1e6 * rate.input * cache_multiplier
     output_cost = output_tokens / 1e6 * rate.output
 
     if cached > 0:
+        # Deliberately hedged. Cache STORAGE is a separate per-token-hour SKU for some model families
+        # and, as far as the published Vertex SKU catalogue goes, not for others: there are storage
+        # SKUs for the 1.5 through 3.6 families and none for 3.7 Flash, whose caching SKUs are all
+        # per-token. Absence from the catalogue is not proof it is free, so this says "may" rather
+        # than asserting a charge that may not exist. Stating a cost that is not real is the same
+        # class of error this module exists to avoid.
         caveats.append(
-            "Context-cache STORAGE is billed per token-hour and is not reported here, "
-            "so the figure runs slightly low on repositories reviewed infrequently."
+            "Cache reads are priced here, but context-cache STORAGE, where the model charges for it "
+            "separately per token-hour, is not included, so the figure can run slightly low."
         )
 
     return Cost(

--- a/tests/test_post_retry.py
+++ b/tests/test_post_retry.py
@@ -1,0 +1,55 @@
+"""Tests for retrying transient GitHub failures when posting a review."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from gemini_review.github import POST_RETRIES, RETRYABLE_STATUS, post_with_retry
+
+
+def response(status):
+    r = Mock()
+    r.status_code = status
+    r.text = f"status {status}"
+    return r
+
+
+@pytest.fixture(autouse=True)
+def no_sleeping():
+    with patch("gemini_review.github.time.sleep") as slept:
+        yield slept
+
+
+class TestPostWithRetry:
+    def test_success_first_time_makes_one_call(self):
+        with patch("gemini_review.github.requests.post", return_value=response(201)) as post:
+            res = post_with_retry("u", {}, {}, 60)
+        assert res.status_code == 201
+        assert post.call_count == 1
+
+    @pytest.mark.parametrize("status", sorted(RETRYABLE_STATUS))
+    def test_transient_failure_then_success(self, status):
+        with patch("gemini_review.github.requests.post", side_effect=[response(status), response(201)]) as post:
+            res = post_with_retry("u", {}, {}, 60)
+        assert res.status_code == 201
+        assert post.call_count == 2
+
+    def test_gives_up_after_the_retry_budget_and_returns_the_last_response(self):
+        with patch("gemini_review.github.requests.post", return_value=response(503)) as post:
+            res = post_with_retry("u", {}, {}, 60)
+        assert res.status_code == 503
+        assert post.call_count == POST_RETRIES + 1
+
+    @pytest.mark.parametrize("status", [403, 404, 422])
+    def test_permanent_failures_are_not_retried(self, status):
+        """A 403 will fail identically however many times it is sent."""
+        with patch("gemini_review.github.requests.post", return_value=response(status)) as post:
+            res = post_with_retry("u", {}, {}, 60)
+        assert res.status_code == status
+        assert post.call_count == 1
+
+    def test_it_waits_between_attempts(self, no_sleeping):
+        with patch("gemini_review.github.requests.post", return_value=response(503)):
+            post_with_retry("u", {}, {}, 60)
+        assert no_sleeping.call_count == POST_RETRIES
+        assert all(call.args[0] > 0 for call in no_sleeping.call_args_list)

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -148,3 +148,32 @@ class TestRateTable:
         for key in RATES:
             assert key == key.lower()
             assert "models/" not in key
+
+
+class TestCacheReadMultiplier:
+    """A rate that sets cache_read=0.0 means free cache reads, not "unset"."""
+
+    def test_zero_cache_read_is_honoured_not_treated_as_missing(self, monkeypatch):
+        from gemini_review import pricing
+
+        free = Rate(input=1.0, output=2.0, label="Free cache reads", cache_read=0.0)
+        monkeypatch.setitem(pricing.RATES, "free-cache-model", free)
+        cost = estimate_cost(usage(cached=1_000_000), "free-cache-model")
+        assert cost.cached_input == 0.0
+        assert cost.total == 0.0
+
+    def test_unset_cache_read_falls_back_to_the_default_multiple(self, monkeypatch):
+        from gemini_review import pricing
+
+        plain = Rate(input=1.0, output=2.0, label="No cache_read set")
+        monkeypatch.setitem(pricing.RATES, "plain-model", plain)
+        cost = estimate_cost(usage(cached=1_000_000), "plain-model")
+        assert cost.cached_input == pytest.approx(0.1)
+
+    def test_storage_caveat_is_hedged_not_asserted(self):
+        """Some model families have a per-token-hour storage SKU and some do not."""
+        cost = estimate_cost(usage(fresh=10, cached=10), "gemini-3.6-flash")
+        storage = [c for c in cost.caveats if "STORAGE" in c]
+        assert storage, "expected a storage caveat when cache was used"
+        assert "where the model charges for it" in storage[0]
+        assert "is billed per token-hour" not in storage[0]


### PR DESCRIPTION
Three small fixes, all found by running this action on four repositories today, most of it during a GitHub incident. Rebased on `main` after #34.

## 1. Retry transient failures when posting (the substantive one)

Your d963d01 makes a failed post fail loudly, which is the right call and I am glad it landed before I got there. This is the complementary half: **try not to lose the review in the first place.**

During today's incident the reviewer computed **three complete reviews, paid for the tokens, and lost every one to 503s on the way back**. The worst was 196,674 input tokens and two genuine findings in a source file that nobody ever saw. The log reads:

```
Failed to submit review atomically (status 503)
Falling back to posting summary and comments individually...
Error posting review summary comment: 503
Error posting comment 1 on agent/.../tools.py (line 833): 503
Error posting comment 2 on agent/.../tools.py (line 911): 503
```

Every one of those was GitHub saying *not now*, not *no*. `post_with_retry` retries **429 and 5xx only**, twice, at 1s and 3s, and routes all three posting calls through it. Other 4xx are not retried, because a 403 or 422 fails identically however many times it is sent.

The budget is deliberately small. A review that arrives four minutes late is not much use on a PR someone is waiting to merge, and with d963d01 in place, failing loudly is now an acceptable outcome. This is for the blip, not for riding out an incident.

## 2. `cache_read=0.0` was treated as unset

`rate.cache_read or DEFAULT_CACHE_READ_MULTIPLIER` falls back to 0.1 when a rate legitimately sets zero, which is exactly what a provider offering free cache reads would look like. Now `is not None`.

**Credit where it is due: this action's own review of #33 caught it**, which is a better advertisement for the tool than anything in the README.

## 3. The cache-storage caveat asserted a charge that may not exist

I wrote *"Context-cache STORAGE is billed per token-hour"* in #33 from general knowledge, and it prints on every review. Checking the Cloud Billing catalogue for Vertex AI (service `C7E2-9256-1C43`) afterwards: there are **37 cache-storage SKUs covering the 1.5 through 3.6 families and none for `gemini-3.7-flash`**, whose 22 caching SKUs are all per-token.

Absence from the catalogue is not proof it is free, so the caveat is now **hedged rather than dropped or asserted**:

> Cache reads are priced here, but context-cache STORAGE, where the model charges for it separately per token-hour, is not included, so the figure can run slightly low.

Stating a cost that is not real is the same class of error the pricing module exists to prevent, so I would rather correct my own text than leave it printing to everyone.

## Verification

`uvx codespell -s`, `uvx ruff check .`, `uvx ruff format --check .` and `uv run pytest` all clean: **118 passing**, 15 new across `tests/test_post_retry.py` and `tests/test_pricing.py`. Retry tests patch `time.sleep`, so the suite still runs in under a second.

Replaying today's exact sequence against the new code:

```
Notice: GitHub returned 503, retrying in 1s (1/2)...
Notice: GitHub returned 503, retrying in 3s (2/2)...
two 503s then recovery -> 201 after 3 attempts (review delivered, not lost)
```
