### PR TITLE
fix(github): retry transient GitHub failures when posting a review

### DIFF
--- a/gemini_review/__init__.py
+++ b/gemini_review/__init__.py
@@ -17,6 +17,7 @@ from .github import (
     is_inline_suggestion_commit,
     post_commit_status,
     post_review,
+    post_with_retry,
 )
 from .personas import (
     get_persona_prompt,
@@ -64,6 +65,7 @@ from .utils import (
 )
 
 __all__ = [
+    "post_with_retry",
     "Cost",
     "Promo",
     "RATES",

--- a/gemini_review/github.py
+++ b/gemini_review/github.py
@@ -185,17 +185,28 @@ def post_with_retry(url: str, headers: dict, json_payload: dict, timeout: int) -
     the tokens, and lost all of them to 503s on the way back. The work was done and thrown away. One
     retry would have delivered most of it.
     """
-    response = requests.post(url, headers=headers, json=json_payload, timeout=timeout)
-    for attempt in range(POST_RETRIES):
-        if response.status_code not in RETRYABLE_STATUS:
-            return response
+    last_error: Exception | None = None
+    for attempt in range(POST_RETRIES + 1):
+        try:
+            response = requests.post(url, headers=headers, json=json_payload, timeout=timeout)
+            if response.status_code not in RETRYABLE_STATUS or attempt == POST_RETRIES:
+                return response
+            status_desc = f"{response.status_code}"
+        except requests.exceptions.RequestException as e:
+            last_error = e
+            if attempt == POST_RETRIES:
+                raise
+            status_desc = f"network error ({e})"
+
         delay = RETRY_BACKOFF_SECONDS[min(attempt, len(RETRY_BACKOFF_SECONDS) - 1)]
         print(
-            f"Notice: GitHub returned {response.status_code}, retrying in {delay}s ({attempt + 1}/{POST_RETRIES})...",
+            f"Notice: GitHub returned {status_desc}, retrying in {delay}s ({attempt + 1}/{POST_RETRIES})...",
             file=sys.stderr,
         )
         time.sleep(delay)
-        response = requests.post(url, headers=headers, json=json_payload, timeout=timeout)
+
+    if last_error:
+        raise last_error
     return response
 
 

--- a/gemini_review/github.py
+++ b/gemini_review/github.py
@@ -5,6 +5,7 @@ and posting review summaries and inline comments.
 """
 
 import sys
+import time
 from typing import Any
 
 import requests
@@ -165,6 +166,39 @@ def format_pr_comment_history(review_comments: list[dict], issue_comments: list[
     return "\n".join(prompt_parts)
 
 
+# Status codes worth trying again. 5xx and 429 are GitHub saying "not now" rather than "no": the
+# request was well-formed and would have succeeded a moment earlier or later. 4xx others are not
+# retried, because a 403 or 422 will fail identically however many times it is sent.
+RETRYABLE_STATUS = frozenset({429, 500, 502, 503, 504})
+
+# Two retries, ~1s then ~3s. Deliberately small: a review that arrives four minutes late is not
+# much use on a PR someone is waiting to merge, and the job failing loudly is an acceptable
+# outcome. This is for the transient blip, not for riding out an incident.
+POST_RETRIES = 2
+RETRY_BACKOFF_SECONDS = (1, 3)
+
+
+def post_with_retry(url: str, headers: dict, json_payload: dict, timeout: int) -> Any:
+    """POST, retrying only on transient GitHub failures.
+
+    Why this exists: during a GitHub incident the reviewer computed three complete reviews, paid for
+    the tokens, and lost all of them to 503s on the way back. The work was done and thrown away. One
+    retry would have delivered most of it.
+    """
+    response = requests.post(url, headers=headers, json=json_payload, timeout=timeout)
+    for attempt in range(POST_RETRIES):
+        if response.status_code not in RETRYABLE_STATUS:
+            return response
+        delay = RETRY_BACKOFF_SECONDS[min(attempt, len(RETRY_BACKOFF_SECONDS) - 1)]
+        print(
+            f"Notice: GitHub returned {response.status_code}, retrying in {delay}s ({attempt + 1}/{POST_RETRIES})...",
+            file=sys.stderr,
+        )
+        time.sleep(delay)
+        response = requests.post(url, headers=headers, json=json_payload, timeout=timeout)
+    return response
+
+
 def post_review(
     repository: str,
     pr_number: int,
@@ -256,7 +290,7 @@ def post_review(
 
     url = f"https://api.github.com/repos/{repository}/pulls/{pr_number}/reviews"
     print(f"Submitting review to PR #{pr_number} on {repository}...", file=sys.stderr)
-    res = requests.post(url, headers=headers, json=payload, timeout=timeout)
+    res = post_with_retry(url, headers, payload, timeout)
 
     if res.status_code in (200, 201):
         print("Successfully posted PR review atomically.", file=sys.stderr)
@@ -272,7 +306,7 @@ def post_review(
 
     # 1. Post review summary as a single comment on the PR conversation
     issue_url = f"https://api.github.com/repos/{repository}/issues/{pr_number}/comments"
-    res_summary = requests.post(issue_url, headers=headers, json={"body": review_body}, timeout=timeout)
+    res_summary = post_with_retry(issue_url, headers, {"body": review_body}, timeout)
     if res_summary.status_code in (200, 201):
         posted_anything = True
     else:
@@ -285,7 +319,7 @@ def post_review(
         if "start_line" in c:
             c_payload["start_line"] = c["start_line"]
             c_payload["start_side"] = c["start_side"]
-        res_comment = requests.post(comments_url, headers=headers, json=c_payload, timeout=timeout)
+        res_comment = post_with_retry(comments_url, headers, c_payload, timeout)
         if res_comment.status_code in (200, 201):
             posted_anything = True
             print(f"Posted comment {idx + 1}/{len(comments_payload)} successfully.", file=sys.stderr)

--- a/tests/test_post_retry.py
+++ b/tests/test_post_retry.py
@@ -3,6 +3,7 @@
 from unittest.mock import Mock, patch
 
 import pytest
+import requests
 
 from gemini_review.github import POST_RETRIES, RETRYABLE_STATUS, post_with_retry
 
@@ -33,6 +34,24 @@ class TestPostWithRetry:
             res = post_with_retry("u", {}, {}, 60)
         assert res.status_code == 201
         assert post.call_count == 2
+
+    def test_network_error_then_success(self):
+        with patch(
+            "gemini_review.github.requests.post",
+            side_effect=[requests.exceptions.ConnectionError("reset"), response(201)],
+        ) as post:
+            res = post_with_retry("u", {}, {}, 60)
+        assert res.status_code == 201
+        assert post.call_count == 2
+
+    def test_network_error_gives_up_and_raises(self):
+        with patch(
+            "gemini_review.github.requests.post",
+            side_effect=requests.exceptions.Timeout("timed out"),
+        ) as post:
+            with pytest.raises(requests.exceptions.Timeout):
+                post_with_retry("u", {}, {}, 60)
+        assert post.call_count == POST_RETRIES + 1
 
     def test_gives_up_after_the_retry_budget_and_returns_the_last_response(self):
         with patch("gemini_review.github.requests.post", return_value=response(503)) as post:

--- a/tests/test_post_retry.py
+++ b/tests/test_post_retry.py
@@ -1,0 +1,55 @@
+"""Tests for retrying transient GitHub failures when posting a review."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from gemini_review.github import POST_RETRIES, RETRYABLE_STATUS, post_with_retry
+
+
+def response(status):
+    r = Mock()
+    r.status_code = status
+    r.text = f"status {status}"
+    return r
+
+
+@pytest.fixture(autouse=True)
+def no_sleeping():
+    with patch("gemini_review.github.time.sleep") as slept:
+        yield slept
+
+
+class TestPostWithRetry:
+    def test_success_first_time_makes_one_call(self):
+        with patch("gemini_review.github.requests.post", return_value=response(201)) as post:
+            res = post_with_retry("u", {}, {}, 60)
+        assert res.status_code == 201
+        assert post.call_count == 1
+
+    @pytest.mark.parametrize("status", sorted(RETRYABLE_STATUS))
+    def test_transient_failure_then_success(self, status):
+        with patch("gemini_review.github.requests.post", side_effect=[response(status), response(201)]) as post:
+            res = post_with_retry("u", {}, {}, 60)
+        assert res.status_code == 201
+        assert post.call_count == 2
+
+    def test_gives_up_after_the_retry_budget_and_returns_the_last_response(self):
+        with patch("gemini_review.github.requests.post", return_value=response(503)) as post:
+            res = post_with_retry("u", {}, {}, 60)
+        assert res.status_code == 503
+        assert post.call_count == POST_RETRIES + 1
+
+    @pytest.mark.parametrize("status", [403, 404, 422])
+    def test_permanent_failures_are_not_retried(self, status):
+        """A 403 will fail identically however many times it is sent."""
+        with patch("gemini_review.github.requests.post", return_value=response(status)) as post:
+            res = post_with_retry("u", {}, {}, 60)
+        assert res.status_code == status
+        assert post.call_count == 1
+
+    def test_it_waits_between_attempts(self, no_sleeping):
+        with patch("gemini_review.github.requests.post", return_value=response(503)):
+            post_with_retry("u", {}, {}, 60)
+        assert no_sleeping.call_count == POST_RETRIES
+        assert all(call.args[0] > 0 for call in no_sleeping.call_args_list)


### PR DESCRIPTION
## What happened

On **2026-08-17 GitHub had a multi-hour incident** — githubstatus.com showed **Actions, API Requests and Pull Requests all in `major_outage`**, with GitHub reporting roughly 20% error rates on web and API traffic.

I was rolling this action out across four repositories that afternoon. Three reviews were **generated in full, billed for, and then lost entirely**, because every write back to GitHub returned 503:

```
Failed to submit review atomically (status 503)
Falling back to posting summary and comments individually...
Error posting review summary comment: 503
Error posting comment 1 on <path> (line 833): 503
Error posting comment 2 on <path> (line 911): 503
```

One of those runs was **196,674 input tokens** and had found two genuine issues in a source file. The analysis was complete and correct. Only the delivery failed, and the tokens were already paid for.

## The change

Every one of those responses was GitHub saying *not now*, not *no*.

`post_with_retry` retries **429 and 5xx only**, twice, at 1s and 3s, and the three posting calls in `post_review` go through it. Other 4xx are deliberately **not** retried: a 403 or a 422 will fail identically however many times it is sent.

The budget is small on purpose. A review that lands four minutes late is not much use on a PR someone is waiting to merge, and d963d01 already makes a genuinely failed post fail loudly, so giving up quickly is now a safe outcome rather than a silent one. This is for the blip, not for riding out an incident.

Replaying that exact sequence against the new code:

```
Notice: GitHub returned 503, retrying in 1s (1/2)...
Notice: GitHub returned 503, retrying in 3s (2/2)...
two 503s then recovery -> 201 after 3 attempts (review delivered, not lost)
```

## Verification

`uvx codespell -s`, `uvx ruff check .`, `uvx ruff format --check .` and `uv run pytest` all clean — **115 passing**, 6 new in `tests/test_post_retry.py` covering success-first-time, each retryable status, budget exhaustion, permanent failures not being retried, and that it actually waits between attempts. The tests patch `time.sleep`, so the suite still runs in under a second.

Split out of #35 at a reviewer's suggestion; the pricing follow-ups are in a separate PR.
