### PR TITLE
fix(pricing): honour cache_read=0.0, and stop asserting a cache-storage charge

### DIFF
--- a/gemini_review/pricing.py
+++ b/gemini_review/pricing.py
@@ -154,13 +154,22 @@ def estimate_cost(usage: dict, model: str | None, config: dict | None = None, to
     output_tokens = max(0, usage.get("candidates_tokens", 0))
 
     uncached_cost = full_price_input / 1e6 * rate.input
-    cached_cost = cached / 1e6 * rate.input * (rate.cache_read or DEFAULT_CACHE_READ_MULTIPLIER)
+    # `is not None` rather than `or`: a rate that legitimately sets cache_read=0.0, which is what a
+    # provider offering free cache reads would look like, is falsy and would silently fall back to 0.1.
+    cache_multiplier = rate.cache_read if rate.cache_read is not None else DEFAULT_CACHE_READ_MULTIPLIER
+    cached_cost = cached / 1e6 * rate.input * cache_multiplier
     output_cost = output_tokens / 1e6 * rate.output
 
     if cached > 0:
+        # Deliberately hedged. Cache STORAGE is a separate per-token-hour SKU for some model families
+        # and, as far as the published Vertex SKU catalogue goes, not for others: there are storage
+        # SKUs for the 1.5 through 3.6 families and none for 3.7 Flash, whose caching SKUs are all
+        # per-token. Absence from the catalogue is not proof it is free, so this says "may" rather
+        # than asserting a charge that may not exist. Stating a cost that is not real is the same
+        # class of error this module exists to avoid.
         caveats.append(
-            "Context-cache STORAGE is billed per token-hour and is not reported here, "
-            "so the figure runs slightly low on repositories reviewed infrequently."
+            "Cache reads are priced here, but context-cache STORAGE, where the model charges for it "
+            "separately per token-hour, is not included, so the figure can run slightly low."
         )
 
     return Cost(

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -148,3 +148,32 @@ class TestRateTable:
         for key in RATES:
             assert key == key.lower()
             assert "models/" not in key
+
+
+class TestCacheReadMultiplier:
+    """A rate that sets cache_read=0.0 means free cache reads, not "unset"."""
+
+    def test_zero_cache_read_is_honoured_not_treated_as_missing(self, monkeypatch):
+        from gemini_review import pricing
+
+        free = Rate(input=1.0, output=2.0, label="Free cache reads", cache_read=0.0)
+        monkeypatch.setitem(pricing.RATES, "free-cache-model", free)
+        cost = estimate_cost(usage(cached=1_000_000), "free-cache-model")
+        assert cost.cached_input == 0.0
+        assert cost.total == 0.0
+
+    def test_unset_cache_read_falls_back_to_the_default_multiple(self, monkeypatch):
+        from gemini_review import pricing
+
+        plain = Rate(input=1.0, output=2.0, label="No cache_read set")
+        monkeypatch.setitem(pricing.RATES, "plain-model", plain)
+        cost = estimate_cost(usage(cached=1_000_000), "plain-model")
+        assert cost.cached_input == pytest.approx(0.1)
+
+    def test_storage_caveat_is_hedged_not_asserted(self):
+        """Some model families have a per-token-hour storage SKU and some do not."""
+        cost = estimate_cost(usage(fresh=10, cached=10), "gemini-3.6-flash")
+        storage = [c for c in cost.caveats if "STORAGE" in c]
+        assert storage, "expected a storage caveat when cache was used"
+        assert "where the model charges for it" in storage[0]
+        assert "is billed per token-hour" not in storage[0]


### PR DESCRIPTION
Two small follow-ups to #33, both my own bugs. Split out of #35 so the retry change can be judged separately.

## 1. `cache_read=0.0` was treated as unset

```python
rate.cache_read or DEFAULT_CACHE_READ_MULTIPLIER
```

`0.0` is falsy, so a rate that legitimately prices cache reads at zero — which is what a provider offering free cache reads would look like — silently falls back to `0.1x`. Now `is not None`.

Latent today, since no rate in the table sets it. Worth fixing because the failure mode is a wrong number rather than an error.

**Credit where it is due: this action's own review of #33 caught it.** That is a better demonstration of the tool than anything in the README.

## 2. The storage caveat asserted a charge that may not exist

Every cached review currently prints:

> Context-cache STORAGE is billed per token-hour and is not reported here, so the figure runs slightly low on repositories reviewed infrequently.

I wrote that from general knowledge. Checking the **Cloud Billing catalogue for Vertex AI** afterwards (service `C7E2-9256-1C43`): there are **37 cache-storage SKUs** covering the 1.5 through 3.6 families, and **none for `gemini-3.7-flash`**, whose 22 caching SKUs are all per-token. So for the action's own default model, that charge may not exist at all.

Absence from the catalogue is not proof it is free, so the caveat is **hedged rather than dropped or asserted**:

> Cache reads are priced here, but context-cache STORAGE, where the model charges for it separately per token-hour, is not included, so the figure can run slightly low.

Stating a cost that is not real is precisely the class of error this module was written to prevent, so I would rather correct my own text than leave it printing to every user.

## Verification

`uvx codespell -s`, `uvx ruff check .`, `uvx ruff format --check .` and `uv run pytest` all clean — **107 passing**, 3 new covering `cache_read=0.0` being honoured, an unset `cache_read` still defaulting to 0.1x, and the caveat being hedged rather than asserted.
