### PR TITLE
ci(metrics): add workflow and badge to track action usage

### DIFF
--- a/.github/badges/gemini-review-action.json
+++ b/.github/badges/gemini-review-action.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "used by",
+  "message": "syncing...",
+  "color": "blue"
+}

--- a/.github/workflows/track-usage.yml
+++ b/.github/workflows/track-usage.yml
@@ -1,0 +1,26 @@
+name: Track Action Usage
+
+on:
+  schedule:
+    # Run daily at 04:00 UTC
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  track-usage:
+    name: Count Action Users
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Count Action Users
+        uses: cicirello/count-action-users@v1
+        with:
+          action-list: derailed-dash/gemini-review-action
+          target-directory: .github/badges
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 ![Dazbo's Gemini Review & Triage Banner](assets/gemini_review_banner.png)
 
+[![Used by](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/derailed-dash/gemini-review-action/main/.github/badges/gemini-review-action.json&logo=githubactions&logoColor=white&label=used%20by)](https://github.com/derailed-dash/gemini-review-action)
+[![GitHub release](https://img.shields.io/github/v/release/derailed-dash/gemini-review-action?logo=github)](https://github.com/derailed-dash/gemini-review-action/releases)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
 **Automated, Google Gemini-based Pull Request reviews and Issue Triaging for all your GitHub repositories and CI/CD pipelines.**
 
 ![Automated PR Review Output Example](assets/review-output.png)


### PR DESCRIPTION
## Description
Adds automated tracking and a public README badge to measure and display how many public GitHub repositories and workflows are currently using `gemini-review-action`.

### Key Additions
- **`.github/workflows/track-usage.yml`**: A daily scheduled workflow (runs at `04:00 UTC` and on `workflow_dispatch`) leveraging [`cicirello/count-action-users@v1`](https://github.com/cicirello/count-action-users) to query GitHub Search and update adoption metrics.
- **`.github/badges/gemini-review-action.json`**: Shields.io endpoint seed file to ensure badges render gracefully.
- **`README.md`**: Embedded dynamic **Used by**, **Latest Release**, and **License** badges beneath the project header banner.

## Related Issue
<!-- If applicable, link to the related issue (e.g. Closes #123) -->
N/A

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 📝 Documentation update
- [ ] ♻️ Code refactoring
- [ ] 🧪 Test coverage improvement
- [x] 📦 Dependency or tooling update

## Contributor Checklist
- [x] My code follows the project guidelines and passes linters: `uvx ruff check .` and `uvx codespell -s`
- [x] I have added or updated tests covering my changes: `uv run pytest`
- [x] All tests pass locally
