### PR TITLE
docs: recommend SHA pinning, and warn about workflow-level concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,34 @@ After adding the workflow to your repository, it should look something like this
 
 ![gemini-review.yml included in your repo](assets/including-the-workflow.png)
 
+### Pinning
+
+The examples above use floating tags (`@v1`, `@v6`) because they are easier to read. For anything beyond a personal repo, **pin to a full commit SHA instead**:
+
+```yaml
+- uses: derailed-dash/gemini-review-action@<40-char-sha> # v1.6.0
+```
+
+This action's job holds `pull-requests: write` and, on the WIF path, `id-token: write`, and it runs against **untrusted pull request head content**. A tag is a movable reference, so a re-tagged release executes in that job without anyone reviewing the change. A SHA is not movable. The same applies to `actions/checkout` and `google-github-actions/auth` in the same job.
+
+Dependabot understands SHA pins with a trailing version comment and will raise a PR when a new release lands, so you still get updates, just deliberately.
+
+### A caveat if you add `concurrency`
+
+Not in the examples, but a natural addition to avoid paying for three reviews when someone pushes three times in a minute. **Put it under the job, not at workflow level:**
+
+```yaml
+jobs:
+  review:
+    concurrency:
+      group: gemini-review-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event_name }}
+      cancel-in-progress: true
+```
+
+Workflow-level `concurrency` is evaluated when a run is **queued**, before any job `if` is evaluated. An `issue_comment` payload has no top-level `pull_request`, so a key like `${{ github.event.pull_request.number || github.event.issue.number }}` falls through to the issue number, which for a pull request is the same number. Both trigger types then share one group.
+
+The result is that **any comment on the PR cancels a review that is still running**, before the job gets to check whether the comment was a `/gemini-review` command at all. Keeping it at job level, and including `github.event_name` in the key, avoids both halves.
+
 ### Seeing It In Action
 
 1. Create a PR in the repository:

--- a/starter-examples/gemini-review.yml
+++ b/starter-examples/gemini-review.yml
@@ -33,14 +33,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6 # pin to a commit SHA in your own repo, see README
         with:
           # Automatically checks out the head ref for PR events,
           # and pulls the PR head branch for comment-based triggers
           ref: ${{ github.event.pull_request.head.sha || format('refs/pull/{0}/head', github.event.issue.number) }}
 
       - name: Run Gemini Review Action
-        uses: derailed-dash/gemini-review-action@v1
+        uses: derailed-dash/gemini-review-action@v1 # or a commit SHA, see README > Pinning
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Two things learned running this action across four repositories today. **Neither is a bug in the action**, both are ways a user can get it wrong, and I got one of them wrong myself.

## 1. Recommend SHA pinning

The examples use `@v1` and `@v6` because they read better, and for a personal repo that is fine. But the job holds `pull-requests: write`, on the WIF path `id-token: write`, and it checks out **untrusted pull request head content**. A tag is a movable reference, so a re-tagged release executes in that job without anyone having reviewed the change.

Adds a short **Pinning** section and a pointer from both examples, covering `actions/checkout` and `google-github-actions/auth` in the same job as well as this action.

Also notes that Dependabot understands SHA pins with a trailing version comment, so users still get update PRs, just deliberately.

## 2. A caveat about `concurrency`

Not in your examples, but a natural thing to add so three pushes in a minute do not mean three paid reviews. **I added it at workflow level, and it silently broke the action.**

Workflow-level `concurrency` is evaluated when a run is **queued**, before any job `if`. An `issue_comment` payload has no top-level `pull_request`, so a key like `${{ github.event.pull_request.number || github.event.issue.number }}` falls through to the issue number, which for a PR is the same number. Both trigger types then share one group.

Result: **any comment on the PR cancels a review that is still running**, before the job checks whether the comment was a `/gemini-review` command at all. Someone types "lgtm", the in-flight review dies, nothing reruns it.

Documented with the job-level form and `github.event_name` in the key.

Found by another AI reviewer on one of my own PRs, which is a decent argument for the whole category.

Docs only, no behaviour change. `ruff`, `codespell` and `pytest` clean.
