### PR TITLE
fix: cap attached file content so one large file cannot kill the review

### DIFF
--- a/gemini_pr_review.py
+++ b/gemini_pr_review.py
@@ -63,6 +63,7 @@ from gemini_review import (
     parse_skill_metadata,
     post_commit_status,
     post_review,
+    prompt_token_budget,
     resolve_persona_name,
     sanitize_code_suggestion,
     search_google_developer_knowledge,
@@ -282,11 +283,34 @@ def main():
                 file=sys.stderr,
             )
 
-    pr_diff_prompt = build_pr_diff_prompt(text_files)
+    pr_diff_prompt = build_pr_diff_prompt(text_files, config)
     dynamic_pr_prompt = f"{pr_diff_prompt}\n\n{comment_history_str}" if comment_history_str else pr_diff_prompt
     codebase_context = build_codebase_context(text_files, config, client=client, model=model_name)
 
     full_prompt = f"{dynamic_pr_prompt}\n\n{codebase_context}" if codebase_context else dynamic_pr_prompt
+
+    # Backstop. Per-file caps stop ONE huge file taking the review down; they cannot stop
+    # many files each under the cap. Check here rather than letting the API reject it: a
+    # 400 costs the entire review and posts nothing, whereas dropping repository context
+    # still produces a real review of the diff.
+    budget = prompt_token_budget(model_name, config)
+    prompt_tokens = count_text_tokens(client, model_name, full_prompt)
+    if prompt_tokens > budget and codebase_context:
+        print(
+            f"Context budget: prompt is {prompt_tokens:,} tokens against a budget of {budget:,}. "
+            "Dropping repository context and reviewing the diff alone.",
+            file=sys.stderr,
+        )
+        codebase_context = ""
+        full_prompt = dynamic_pr_prompt
+        prompt_tokens = count_text_tokens(client, model_name, full_prompt)
+
+    if prompt_tokens > budget:
+        print(
+            f"Context budget: the PR diff alone is {prompt_tokens:,} tokens, over the {budget:,} budget for "
+            "this model. Lower GEMINI_MAX_FILE_BYTES, raise GEMINI_MAX_PROMPT_TOKENS, or split the PR.",
+            file=sys.stderr,
+        )
 
     enable_caching = config.get("enable_context_caching", True)
     cache_ttl_seconds = config.get("cache_ttl_seconds", 3600)

--- a/gemini_review/__init__.py
+++ b/gemini_review/__init__.py
@@ -10,6 +10,11 @@ from .billing_labels import (
     sanitise,
     sanitise_key,
 )
+from .budget import (
+    cap_file_content,
+    max_file_bytes,
+    prompt_token_budget,
+)
 from .config import DEFAULT_TIMEOUT, load_config
 from .developer_knowledge import (
     get_google_auth_headers,
@@ -123,4 +128,7 @@ __all__ = [
     "sanitize_code_suggestion",
     "search_google_developer_knowledge",
     "select_dynamic_context_files",
+    "prompt_token_budget",
+    "cap_file_content",
+    "max_file_bytes",
 ]

--- a/gemini_review/budget.py
+++ b/gemini_review/budget.py
@@ -1,0 +1,148 @@
+"""
+Description: Size limits for anything attached to the review prompt.
+
+The failure this exists to prevent: a single generated file in a PR blows the model's
+input window and the whole review dies with a 400, posting nothing.
+
+    400 INVALID_ARGUMENT. The input token count exceeds the maximum
+    number of tokens allowed 1048576.
+
+That was one 2.9 MB `docs/openapi.json` in a 42-file PR, roughly 980k tokens on its own.
+Its *diff* was 4 KB. The action attached the full current content of every changed text
+file with no size limit, so the review was lost to a file nobody was reviewing.
+
+Two rules, because they fail differently:
+
+1. **Per-file cap, applied at every point where full file content is attached.** Cheap,
+   deterministic, needs no API call. This is the one that actually prevents the failure.
+2. **A preflight total, checked once before the expensive call.** A backstop for the case
+   the per-file cap cannot catch: many files each under the cap that together exceed the
+   window.
+
+Why a cap and not a longer exclusion list: the existing guard is a set of filenames
+(`package-lock.json`, `uv.lock`, `.env`). `package-lock.json` is on it because someone
+thought of it; a generated OpenAPI spec is not, because nobody did. Enumerating bad names
+fails on the next generated file, and every repo has a different one — a snapshot, a
+bundled schema, a fixture, a vendored client. A byte cap catches all of them, including
+the ones not invented yet.
+
+Truncation is deliberately loud. A silently shortened file is worse than an absent one,
+because the model reasons confidently about content it cannot see and nobody reading the
+review can tell.
+"""
+
+import os
+import sys
+
+# Per-file ceiling on ATTACHED FULL CONTENT. Diffs are never capped by this: the diff is
+# the thing under review, and diffs are small even for enormous files.
+#
+# 128 KB is about 32k tokens, so a handful of capped files still leaves room in a 1M
+# window. It is comfortably above real source files — the largest hand-written file in the
+# repos this was tested against is under 60 KB — so in practice this only ever bites
+# generated artifacts, which is the intent.
+DEFAULT_MAX_FILE_BYTES = 128 * 1024
+
+# Published input windows. Used only to pick a preflight budget; an unknown model falls
+# back to the smallest known value rather than assuming the largest, so a new model id
+# fails safe (a trimmed review) instead of unsafe (a 400 and no review).
+MODEL_INPUT_TOKEN_LIMITS: dict[str, int] = {
+    "gemini-3.7-flash": 1_048_576,
+    "gemini-3.6-flash": 1_048_576,
+    "gemini-2.5-flash": 1_048_576,
+    "gemini-2.5-pro": 1_048_576,
+}
+_FALLBACK_INPUT_TOKEN_LIMIT = 1_048_576
+
+# Leave headroom. The count is taken on the prompt text, but the request also carries the
+# system instruction, tool declarations and the response schema, none of which are in it.
+DEFAULT_PROMPT_TOKEN_HEADROOM = 0.90
+
+
+def _normalise_model(model: str | None) -> str:
+    if not model:
+        return ""
+    name = model.strip().lower()
+    if "models/" in name:
+        name = name.split("models/")[-1]
+    return name
+
+
+def input_token_limit(model: str | None) -> int:
+    """The input window for `model`, defaulting to the smallest known limit."""
+    return MODEL_INPUT_TOKEN_LIMITS.get(_normalise_model(model), _FALLBACK_INPUT_TOKEN_LIMIT)
+
+
+def prompt_token_budget(model: str | None, config: dict | None = None) -> int:
+    """How many tokens the assembled prompt may occupy."""
+    config = config or {}
+    explicit = _int_setting("GEMINI_MAX_PROMPT_TOKENS", config, "max_prompt_tokens", 0)
+    if explicit > 0:
+        return explicit
+    return int(input_token_limit(model) * DEFAULT_PROMPT_TOKEN_HEADROOM)
+
+
+def _int_setting(env_var: str, config: dict, config_key: str, default: int) -> int:
+    """An int from the environment, else gemini-review.toml, else the default.
+
+    A malformed value falls back rather than raising. This is a guard rail: a typo in a
+    config file should not be the reason a review fails to post.
+    """
+    if env_var in os.environ:
+        try:
+            return int(os.environ[env_var])
+        except ValueError:
+            print(
+                f"Warning: {env_var}='{os.environ[env_var]}' is not an integer. Using the configured default.",
+                file=sys.stderr,
+            )
+    value = (config or {}).get(config_key, default)
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def max_file_bytes(config: dict | None = None) -> int:
+    """Per-file ceiling on attached full content. 0 or negative disables the cap."""
+    return _int_setting("GEMINI_MAX_FILE_BYTES", config or {}, "max_file_bytes", DEFAULT_MAX_FILE_BYTES)
+
+
+def cap_file_content(content: str, filename: str, limit: int) -> tuple[str, bool]:
+    """Return `content` truncated to `limit` bytes, and whether it was truncated.
+
+    Truncation is on a line boundary so the retained portion stays parseable, and carries
+    a marker naming the file and both sizes. The marker is the point: it tells the model
+    the file continues, and it tells a human reading the review why a finding might be
+    partial.
+    """
+    if not content or limit <= 0:
+        return content, False
+
+    encoded = content.encode("utf-8", errors="replace")
+    if len(encoded) <= limit:
+        return content, False
+
+    kept = encoded[:limit].decode("utf-8", errors="ignore")
+    # Drop the final, probably half-written line.
+    newline = kept.rfind("\n")
+    if newline > 0:
+        kept = kept[:newline]
+
+    marker = (
+        f"\n\n[TRUNCATED by gemini-review: '{filename}' is {len(encoded):,} bytes, "
+        f"showing the first {limit:,}. The rest of this file was NOT provided. "
+        f"Do not draw conclusions about the omitted portion.]"
+    )
+    return kept + marker, True
+
+
+def report_capped(filenames: list[str], limit: int) -> None:
+    """Say once, on stderr, which files were shortened. Silence here is the real hazard."""
+    if not filenames:
+        return
+    print(
+        f"Context budget: truncated {len(filenames)} file(s) to {limit:,} bytes of full content "
+        f"(diffs are unaffected): {', '.join(filenames)}",
+        file=sys.stderr,
+    )

--- a/gemini_review/prompts.py
+++ b/gemini_review/prompts.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from google.genai import types
 
+from gemini_review.budget import cap_file_content, max_file_bytes, report_capped
 from gemini_review.personas import get_persona_prompt, resolve_persona_name
 from gemini_review.schemas import DynamicContextSelection
 from gemini_review.utils import (
@@ -159,8 +160,14 @@ def load_system_instruction(repository: str | None, pr_number: int, config: dict
     return base_prompt
 
 
-def build_pr_diff_prompt(files: list) -> str:
-    """Build the dynamic PR diff patch prompt for modified files."""
+def build_pr_diff_prompt(files: list, config: dict | None = None) -> str:
+    """Build the dynamic PR diff patch prompt for modified files.
+
+    The DIFF is always attached in full: it is what is under review, and it stays small
+    even for enormous files. The FULL CURRENT CONTENT is capped per file, because one
+    generated artifact (an OpenAPI spec, a snapshot, a bundled schema) can exceed the
+    model's entire input window on its own and take the whole review down with it.
+    """
     fn_is_text_file = _get_pr_review_func("is_text_file", is_text_file)
     fn_get_file_content = _get_pr_review_func("get_file_content", get_file_content)
     fn_format_diff_patch = _get_pr_review_func(
@@ -169,6 +176,9 @@ def build_pr_diff_prompt(files: list) -> str:
     fn_format_file_content = _get_pr_review_func(
         "format_file_content_with_line_numbers", format_file_content_with_line_numbers
     )
+
+    limit = max_file_bytes(config)
+    capped: list[str] = []
 
     prompt_parts = []
     prompt_parts.append("Below are the files and changes included in this Pull Request:\n")
@@ -182,6 +192,10 @@ def build_pr_diff_prompt(files: list) -> str:
             continue
 
         full_content = fn_get_file_content(filename)
+        if full_content:
+            full_content, was_capped = cap_file_content(full_content, filename, limit)
+            if was_capped:
+                capped.append(filename)
 
         prompt_parts.append(f"=== File: {filename} ===")
         prompt_parts.append(f"Status: {status}")
@@ -192,6 +206,7 @@ def build_pr_diff_prompt(files: list) -> str:
             prompt_parts.append(fn_format_file_content(full_content))
         prompt_parts.append("=========================\n")
 
+    report_capped(capped, limit)
     return "\n".join(prompt_parts)
 
 
@@ -217,6 +232,8 @@ def build_codebase_context(
             max_context_bytes = int(os.environ["GEMINI_MAX_CONTEXT_BYTES"])
         except ValueError:
             pass
+
+    file_byte_limit = max_file_bytes(config)
 
     max_core_context_bytes = config.get("max_core_context_bytes", 500 * 1024)
     if "GEMINI_MAX_CORE_CONTEXT_BYTES" in os.environ:
@@ -356,6 +373,7 @@ def build_codebase_context(
 
             prompt_parts.append("--- Key Configuration and Documentation Files ---")
             core_files_included = []
+            core_capped: list[str] = []
             core_bytes_used = 0
             for f in other_files:
                 if fn_is_core_file(f, core_patterns):
@@ -366,6 +384,10 @@ def build_codebase_context(
                     if core_bytes_used + f_size <= max_core_context_bytes:
                         content = fn_get_file_content(f)
                         if content:
+                            content, was_capped = cap_file_content(content, f, file_byte_limit)
+                            if was_capped:
+                                core_capped.append(f)
+                                f_size = min(f_size, file_byte_limit)
                             prompt_parts.append(f"--- File: {f} ---")
                             prompt_parts.append(content)
                             prompt_parts.append("-----------------\n")
@@ -377,6 +399,7 @@ def build_codebase_context(
                             f" {max_core_context_bytes} bytes).",
                             file=sys.stderr,
                         )
+            report_capped(core_capped, file_byte_limit)
             if core_files_included:
                 print(
                     f"Codebase context: attached {len(core_files_included)} core configuration/documentation files"
@@ -409,12 +432,17 @@ def build_codebase_context(
                     prompt_parts.append("--- Relevant Codebase Context (Dynamically Selected) ---")
                     if reasoning:
                         prompt_parts.append(f"Selection Rationale: {reasoning}\n")
+                    dynamic_capped: list[str] = []
                     for sf in selected_files:
                         content = fn_get_file_content(sf)
                         if content:
+                            content, was_capped = cap_file_content(content, sf, file_byte_limit)
+                            if was_capped:
+                                dynamic_capped.append(sf)
                             prompt_parts.append(f"--- File: {sf} ---")
                             prompt_parts.append(content)
                             prompt_parts.append("-----------------\n")
+                    report_capped(dynamic_capped, file_byte_limit)
 
             prompt_parts.append("==========================================\n")
 
@@ -432,7 +460,7 @@ def build_prompt(
     fn_build_pr_diff_prompt = _get_pr_review_func("build_pr_diff_prompt", build_pr_diff_prompt)
     fn_build_codebase_context = _get_pr_review_func("build_codebase_context", build_codebase_context)
 
-    pr_prompt = fn_build_pr_diff_prompt(files)
+    pr_prompt = fn_build_pr_diff_prompt(files, config)
     parts = [pr_prompt]
     if comment_history:
         parts.append(comment_history)

--- a/gemini_review/utils.py
+++ b/gemini_review/utils.py
@@ -519,8 +519,13 @@ def count_text_tokens(client, model_name: str, text: str) -> int:
     if client and hasattr(client, "models") and hasattr(client.models, "count_tokens"):
         try:
             resp = client.models.count_tokens(model=model_name, contents=text)
-            if hasattr(resp, "total_tokens") and resp.total_tokens is not None:
-                return resp.total_tokens
+            total = getattr(resp, "total_tokens", None)
+            # Must be a real int. A bool is an int in Python and a stub/mock client can
+            # return anything at all; either would be used in arithmetic and formatting
+            # downstream, so an unusable value falls through to the estimate rather than
+            # raising inside a review that is about to be posted.
+            if isinstance(total, int) and not isinstance(total, bool) and total >= 0:
+                return total
         except Exception:
             pass
     # Fallback heuristic (~4 chars per token)

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -1,0 +1,141 @@
+"""Tests for prompt size limits.
+
+The regression these protect against is a real one: a 2.9 MB `docs/openapi.json` in a
+42-file PR produced
+
+    400 INVALID_ARGUMENT. The input token count exceeds the maximum
+    number of tokens allowed 1048576.
+
+and the review was lost. The file's diff was 4 KB; its full content was attached uncapped.
+"""
+
+import pytest
+
+from gemini_review.budget import (
+    DEFAULT_MAX_FILE_BYTES,
+    cap_file_content,
+    input_token_limit,
+    max_file_bytes,
+    prompt_token_budget,
+)
+from gemini_review.prompts import build_pr_diff_prompt
+
+
+class TestCapFileContent:
+    def test_content_under_the_limit_is_untouched(self):
+        text = "line one\nline two\n"
+        out, capped = cap_file_content(text, "a.py", 1000)
+        assert out == text
+        assert capped is False
+
+    def test_content_over_the_limit_is_truncated_and_flagged(self):
+        text = "x" * 5000
+        out, capped = cap_file_content(text, "big.json", 1000)
+        assert capped is True
+        assert len(out.encode()) < len(text.encode())
+        assert "TRUNCATED by gemini-review" in out
+
+    def test_the_marker_names_the_file_and_both_sizes(self):
+        """A silently shortened file is worse than an absent one, so the marker is the point."""
+        out, _ = cap_file_content("y" * 5000, "docs/openapi.json", 1000)
+        assert "docs/openapi.json" in out
+        assert "5,000 bytes" in out
+        assert "1,000" in out
+
+    def test_truncation_lands_on_a_line_boundary(self):
+        text = "\n".join(f"line {i}" for i in range(500))
+        out, _ = cap_file_content(text, "a.py", 100)
+        body = out.split("[TRUNCATED")[0]
+        assert not body.endswith("lin")
+        assert body.rstrip().split("\n")[-1].startswith("line ")
+
+    def test_a_zero_or_negative_limit_disables_capping(self):
+        text = "z" * 10_000
+        assert cap_file_content(text, "a.py", 0) == (text, False)
+        assert cap_file_content(text, "a.py", -1) == (text, False)
+
+    def test_empty_content_is_returned_unchanged(self):
+        assert cap_file_content("", "a.py", 10) == ("", False)
+
+    def test_multibyte_content_does_not_raise_or_exceed_the_byte_limit(self):
+        """The limit is bytes, not characters, and slicing UTF-8 can land mid-codepoint."""
+        text = "é" * 5000  # two bytes each
+        out, capped = cap_file_content(text, "a.txt", 1000)
+        assert capped is True
+        body = out.split("[TRUNCATED")[0].rstrip("\n")
+        assert len(body.encode()) <= 1000
+
+
+class TestLimits:
+    def test_a_known_model_uses_its_published_window(self):
+        assert input_token_limit("gemini-3.7-flash") == 1_048_576
+
+    def test_a_prefixed_model_id_resolves(self):
+        assert input_token_limit("publishers/google/models/GEMINI-3.7-FLASH") == 1_048_576
+
+    def test_an_unknown_model_still_gets_a_usable_limit(self):
+        assert input_token_limit("some-future-model") > 0
+
+    def test_the_budget_leaves_headroom_below_the_window(self):
+        """The count is taken on the prompt; the request also carries system instruction,
+        tools and the response schema, none of which are in it."""
+        assert prompt_token_budget("gemini-3.7-flash") < input_token_limit("gemini-3.7-flash")
+
+    def test_config_can_override_the_budget(self):
+        assert prompt_token_budget("gemini-3.7-flash", {"max_prompt_tokens": 5000}) == 5000
+
+    def test_env_overrides_config_for_the_file_cap(self, monkeypatch):
+        monkeypatch.setenv("GEMINI_MAX_FILE_BYTES", "4096")
+        assert max_file_bytes({"max_file_bytes": 999}) == 4096
+
+    def test_a_malformed_override_falls_back_rather_than_raising(self, monkeypatch):
+        """A typo in config must not be the reason a review fails to post."""
+        monkeypatch.setenv("GEMINI_MAX_FILE_BYTES", "not-a-number")
+        assert max_file_bytes({}) == DEFAULT_MAX_FILE_BYTES
+
+
+class TestDiffPromptIsBounded:
+    """The regression test. Numbers are from doitbse/draft#538."""
+
+    OPENAPI_BYTES = 2_947_014
+
+    @pytest.fixture
+    def huge_file(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        path = tmp_path / "docs"
+        path.mkdir()
+        (path / "openapi.json").write_text("{}" + "a" * self.OPENAPI_BYTES)
+        return [
+            {
+                "filename": "docs/openapi.json",
+                "status": "modified",
+                "patch": "@@ -1 +1 @@\n-old\n+new",
+            }
+        ]
+
+    def test_a_huge_changed_file_no_longer_dominates_the_prompt(self, huge_file):
+        prompt = build_pr_diff_prompt(huge_file)
+        assert len(prompt.encode()) < self.OPENAPI_BYTES / 4, "full content was attached uncapped"
+
+    def test_the_diff_itself_survives_capping(self, huge_file):
+        """The diff is what is under review and must never be dropped to save space."""
+        prompt = build_pr_diff_prompt(huge_file)
+        # Rendered with line numbers by format_diff_patch_with_line_numbers, e.g. "1 + | new".
+        assert "+ | new" in prompt
+        assert "- | old" in prompt
+        assert "docs/openapi.json" in prompt
+
+    def test_the_prompt_says_the_file_was_truncated(self, huge_file):
+        assert "TRUNCATED by gemini-review" in build_pr_diff_prompt(huge_file)
+
+    def test_capping_can_be_disabled_for_a_repo_that_wants_the_old_behaviour(self, huge_file):
+        prompt = build_pr_diff_prompt(huge_file, {"max_file_bytes": 0})
+        assert len(prompt.encode()) > self.OPENAPI_BYTES
+
+    def test_an_ordinary_file_is_attached_in_full(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "app.py").write_text("def hello():\n    return 'world'\n")
+        files = [{"filename": "app.py", "status": "modified", "patch": "@@ -1 +1 @@\n+x"}]
+        prompt = build_pr_diff_prompt(files)
+        assert "return 'world'" in prompt
+        assert "TRUNCATED" not in prompt


### PR DESCRIPTION
## The failure

A PR touching a 2.9 MB generated `docs/openapi.json` failed outright, and no review was posted:

```
google.genai.errors.ClientError: 400 INVALID_ARGUMENT.
{'error': {'code': 400, 'message': 'The input token count exceeds the
maximum number of tokens allowed 1048576.', 'status': 'INVALID_ARGUMENT'}}
```

That file's **diff was 4 KB**. `build_pr_diff_prompt` attaches the *full current content* of every changed text file, and that path has no size limit, so roughly 980k tokens of a file nobody was reviewing crowded out the review.

Nothing was misconfigured. Sparse Context Mode engaged correctly, the core-file budget skipped its overflow correctly, and dynamic selection picked 8 sensible files. All the existing budgets guard the **codebase context**; the PR's own changed files are attached before any of them and are uncapped.

## Measured on that PR, 30 changed text files

| | prompt | approx tokens | |
|---|---|---|---|
| before | 4,309,789 bytes | ~1,436,596 | over the window, 400 |
| after | 919,357 bytes | ~306,452 | fits |

Exactly one file was truncated. The other 29 are attached in full.

## The change

Two layers, because they fail differently.

**1. A per-file cap wherever full content is attached** — the PR diff prompt, core files, and dynamically selected files. Deterministic, no API call, and it is the one that actually prevents the failure. **Diffs are never capped**: the diff is what is under review and stays small even for enormous files.

**2. A preflight token count before `generate_content`.** Per-file caps cannot stop many files that are each under the cap. If the assembled prompt is still over budget, repository context is dropped and the diff is reviewed alone. A trimmed review beats a 400 that posts nothing.

## Why a cap rather than another name in the exclusion list

`is_text_file` excludes by filename:

```python
excluded_names = {"package-lock.json", "uv.lock", ".env", ".env.enc", ".envrc"}
```

`package-lock.json` is there because someone thought of it. A generated OpenAPI spec is not, because nobody did. Every repo has a different one — a snapshot, a bundled schema, a fixture, a vendored client — so enumerating names fails on the next generated file. A byte cap catches the ones not invented yet.

## Truncation is deliberately loud

```
[TRUNCATED by gemini-review: 'docs/openapi.json' is 2,947,014 bytes,
showing the first 131,072. The rest of this file was NOT provided.
Do not draw conclusions about the omitted portion.]
```

A silently shortened file is worse than an absent one: the model reasons confidently about content it cannot see, and nobody reading the review can tell. Truncation lands on a line boundary, and the capped files are also listed once on stderr.

## Defaults and escape hatches

- `max_file_bytes` / `GEMINI_MAX_FILE_BYTES`, default **128 KB** (~32k tokens). Well above any hand-written source file, so in practice it only bites generated artifacts.
- `max_prompt_tokens` / `GEMINI_MAX_PROMPT_TOKENS` for the preflight budget, defaulting to 90% of the model's window. The headroom is because the count is taken on the prompt text, while the request also carries the system instruction, tool declarations and the response schema.
- `max_file_bytes = 0` restores the previous behaviour exactly.
- An unknown model id falls back to the smallest known window, so a new model fails safe (a trimmed review) rather than unsafe (a 400).
- A malformed config value warns and falls back rather than raising. A typo should not be why a review fails to post.

## Also included

`count_text_tokens` now returns the SDK's count only when it is a real int, falling back to the character estimate otherwise. Previously any unexpected value flowed into arithmetic and f-string formatting downstream. One line, and it keeps the guard rail from becoming the crash.

## Tests

19 new tests in `tests/test_budget.py`, including a regression test built from the real PR's numbers. The existing 119 tests are untouched and still pass — **138 total**.