### PR TITLE
feat(review): resolve threads for findings the review reports as addressed

### DIFF
--- a/README.md
+++ b/README.md
@@ -880,5 +880,24 @@ It is deliberately conservative, because resolving the wrong thread hides feedba
 - **Only exact file and line matches.** The model supplies the location alongside each resolved item, and nothing is inferred from the prose. An item the model cannot confidently attribute is reported and its thread left open.
 - **Never fatal.** It runs after the review is posted, and any failure is a warning. A review is never lost to a follow-up API call.
 
-Requires `pull-requests: write`, which the action already needs.
+#### It needs a token that is not `GITHUB_TOKEN`
+
+Verified against a live PR: **the default `GITHUB_TOKEN` cannot resolve review threads.** `viewerCanResolve` returns `false` and the mutation is refused:
+
+```
+FORBIDDEN — Resource not accessible by integration
+```
+
+This is not a missing permission. `pull-requests: write` is already granted and makes no difference; GitHub simply does not let the Actions token resolve threads. Supply a **personal access token** or a **GitHub App installation token** with write access to pull requests:
+
+```yaml
+        with:
+          github_token: ${{ secrets.THREAD_RESOLVER_TOKEN }}
+          resolve_addressed_threads: 'true'
+```
+
+With the default token the action resolves nothing, prints why, and carries on. The review is still posted — the feature degrades rather than failing the job.
+
+If the token posts under an identity other than `github-actions[bot]`, set `GEMINI_REVIEWER_LOGIN` so the action recognises its own threads.
+
 

--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ jobs:
           # persona: 'straight'                # Optional: straight (default), dazbo, palpatine, rick
           # timeout: '60'                     # Optional API timeout in seconds
           # include_comment_history: 'true'   # Optional: include prior PR comment history (default: true)
+          # resolve_addressed_threads: 'false' # Optional: auto-resolve threads the review marks addressed (default: false)
           # skip_inline_suggestions: 'true'   # Optional: skip re-reviews on commits created via GitHub UI inline fixes (default: true)
 ```
 
@@ -390,6 +391,7 @@ jobs:
 | `gemini_model` | The Gemini model version to target for code review and dynamic context selection. | No | `gemini-3.7-flash` |
 | `command` | The mode/command to run: `review` (for PR reviews) or `triage` (for issue triaging). | No | `review` |
 | `include_comment_history` | Whether to fetch prior inline review threads and conversation comments from GitHub. | No | `'true'` |
+| `resolve_addressed_threads` | Resolve the GitHub review threads for findings the action reports as addressed, so *Require conversation resolution before merging* stops blocking on feedback the reviewer has already agreed is done. Only threads opened by this action, and only where the model supplied an exact file and line, are resolved. | No | `'false'` |
 | `language` | The language to use for the review comments (e.g. `English (UK)`, `English (US)`, `French`, `Spanish`). | No | `English (UK)` |
 | `persona` | Reviewer persona overlay (`straight`, `dazbo`, `palpatine`, `rick`). | No | `straight` |
 | `skip_inline_suggestions` | Whether to skip automated re-reviews when a commit is created by accepting an inline suggestion via GitHub UI. | No | `'true'` |
@@ -858,3 +860,25 @@ the built-in table is used instead.
 For official, up-to-date pricing details across all Gemini model tiers and regions:
 * [Google AI Studio Pricing Guide](https://ai.google.dev/pricing)
 * [Google Cloud Vertex AI Pricing Guide](https://cloud.google.com/vertex-ai/generative-ai/pricing)
+
+### Resolving addressed threads
+
+The action already recognises when a prior finding has been fixed and lists it under **Resolved Items from Prior Reviews**. By default it stops there, and the review thread stays open.
+
+That matters if the repository has **Require conversation resolution before merging** enabled: the merge is blocked on a comment the reviewer itself has agreed is done, and someone has to click Resolve by hand on every PR.
+
+Set `resolve_addressed_threads: 'true'` and the action resolves those threads for you.
+
+```yaml
+        with:
+          resolve_addressed_threads: 'true'
+```
+
+It is deliberately conservative, because resolving the wrong thread hides feedback that is still outstanding, which is worse than leaving everything open:
+
+- **Only threads this action opened.** A human reviewer's thread is never touched, whatever the model claims. If the action posts under a PAT or a GitHub App rather than the default token, declare that identity with `GEMINI_REVIEWER_LOGIN` so its own threads are recognised; guessing wrong simply resolves nothing.
+- **Only exact file and line matches.** The model supplies the location alongside each resolved item, and nothing is inferred from the prose. An item the model cannot confidently attribute is reported and its thread left open.
+- **Never fatal.** It runs after the review is posted, and any failure is a warning. A review is never lost to a follow-up API call.
+
+Requires `pull-requests: write`, which the action already needs.
+

--- a/action.yml
+++ b/action.yml
@@ -51,6 +51,15 @@ inputs:
       Developer API has no labels field, so this is ignored when authenticating with an API key.
     required: false
     default: ''
+  resolve_addressed_threads:
+    description: >-
+      Resolve the GitHub review threads for findings this action reports as addressed, so
+      "Require conversation resolution before merging" stops blocking on feedback the reviewer
+      has already agreed is done. Only threads opened by this action, and only where the model
+      supplied an exact file and line, are ever resolved. Off by default: closing a
+      human-visible thread on someone's behalf is opinionated.
+    required: false
+    default: 'false'
   persona:
     description: 'Persona overlay for reviewer (straight, dazbo, palpatine, rick)'
     required: false
@@ -79,6 +88,7 @@ runs:
         GEMINI_MODEL: ${{ inputs.gemini_model }}
         GEMINI_LANGUAGE: ${{ inputs.language }}
         GEMINI_TIMEOUT: ${{ inputs.timeout }}
+        GEMINI_RESOLVE_ADDRESSED_THREADS: ${{ inputs.resolve_addressed_threads }}
         GEMINI_INCLUDE_COMMENT_HISTORY: ${{ inputs.include_comment_history }}
         GEMINI_PERSONA: ${{ inputs.persona }}
         GEMINI_BILLING_LABELS: ${{ inputs.billing_labels }}

--- a/action.yml
+++ b/action.yml
@@ -57,7 +57,9 @@ inputs:
       "Require conversation resolution before merging" stops blocking on feedback the reviewer
       has already agreed is done. Only threads opened by this action, and only where the model
       supplied an exact file and line, are ever resolved. Off by default: closing a
-      human-visible thread on someone's behalf is opinionated.
+      human-visible thread on someone's behalf is opinionated. NOTE: this requires a PAT or
+      GitHub App token in `github_token`; the default GITHUB_TOKEN cannot resolve threads
+      (the mutation is refused with FORBIDDEN) and the action will say so and carry on.
     required: false
     default: 'false'
   persona:

--- a/gemini_pr_review.py
+++ b/gemini_pr_review.py
@@ -64,7 +64,9 @@ from gemini_review import (
     post_commit_status,
     post_review,
     prompt_token_budget,
+    resolve_addressed_threads,
     resolve_persona_name,
+    reviewer_logins,
     sanitize_code_suggestion,
     search_google_developer_knowledge,
     select_dynamic_context_files,
@@ -483,7 +485,8 @@ def main():
         if review.resolved_items:
             print("\n=== RESOLVED ITEMS ===", file=sys.stderr)
             for r in review.resolved_items:
-                print(f"✅ {r}")
+                loc = f" ({r.path}:{r.line})" if getattr(r, "path", None) and getattr(r, "line", None) else ""
+                print(f"✅ {getattr(r, 'description', r)}{loc}")
         print("\n=== GENERAL FEEDBACK ===", file=sys.stderr)
         for gf in review.general_feedback:
             print(f"- {gf}")
@@ -503,6 +506,25 @@ def main():
             config=config,
             event_name=event_name,
         )
+
+        # After the review is posted, not before: resolving threads must never be able to cost us
+        # the review itself, so it runs last and every failure inside it is a warning.
+        if os.environ.get("GEMINI_RESOLVE_ADDRESSED_THREADS", "false").lower() in ("true", "1"):
+            if review.resolved_items:
+                resolve_addressed_threads(
+                    repository,
+                    pr_number,
+                    headers,
+                    review.resolved_items,
+                    bot_logins=reviewer_logins(),
+                    timeout=timeout,
+                )
+        elif review.resolved_items:
+            print(
+                "Note: items were reported as resolved but their threads were left open. "
+                "Set resolve_addressed_threads: true to close them automatically.",
+                file=sys.stderr,
+            )
 
 
 if __name__ == "__main__":

--- a/gemini_review/__init__.py
+++ b/gemini_review/__init__.py
@@ -50,12 +50,13 @@ from .prompts import (
     load_system_instruction,
     select_dynamic_context_files,
 )
-from .schemas import DynamicContextSelection, InlineComment, ReviewResult
+from .schemas import DynamicContextSelection, InlineComment, ResolvedItem, ReviewResult
 from .skills import (
     list_available_skills,
     load_skill_instructions,
     parse_skill_metadata,
 )
+from .threads import fetch_review_threads, resolve_addressed_threads, reviewer_logins
 from .utils import (
     _normalize_model_name,
     count_text_tokens,
@@ -90,6 +91,10 @@ __all__ = [
     "usd",
     "DEFAULT_TIMEOUT",
     "DynamicContextSelection",
+    "ResolvedItem",
+    "fetch_review_threads",
+    "resolve_addressed_threads",
+    "reviewer_logins",
     "InlineComment",
     "ReviewResult",
     "_normalize_model_name",

--- a/gemini_review/github.py
+++ b/gemini_review/github.py
@@ -179,6 +179,24 @@ POST_RETRIES = 2
 RETRY_BACKOFF_SECONDS = (1, 3)
 
 
+def _format_resolved_item(item: Any) -> str:
+    """Render one resolved item. Accepts the structured form or a bare string.
+
+    The string branch exists because a cached or replayed response from before `resolved_items`
+    became structured would otherwise crash the render of an otherwise valid review.
+    """
+    if isinstance(item, str):
+        return item
+    text = getattr(item, "description", None) or str(item)
+    path = getattr(item, "path", None)
+    line = getattr(item, "line", None)
+    if path and line:
+        return f"{text} (`{path}:{line}`)"
+    if path:
+        return f"{text} (`{path}`)"
+    return text
+
+
 def post_with_retry(url: str, headers: dict, json_payload: dict, timeout: int) -> Any:
     """POST, retrying only on transient GitHub failures.
 
@@ -238,7 +256,7 @@ def post_review(
 
     body_sections = [f"## 📋 Review Summary\n\n{review.summary}"]
     if review.resolved_items:
-        resolved_str = "\n".join(f"- {r}" for r in review.resolved_items)
+        resolved_str = "\n".join(f"- {_format_resolved_item(r)}" for r in review.resolved_items)
         body_sections.append(f"### ✅ Resolved Items from Prior Reviews\n\n{resolved_str}")
     if review.general_feedback:
         feedback_str = "\n".join(f"- {f}" for f in review.general_feedback)

--- a/gemini_review/schemas.py
+++ b/gemini_review/schemas.py
@@ -3,7 +3,7 @@ Description: Pydantic schemas for structured Gemini PR review responses.
 Provides Pydantic data schemas for line-specific inline comments and top-level review summaries.
 """
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class InlineComment(BaseModel):
@@ -44,18 +44,62 @@ class InlineComment(BaseModel):
     )
 
 
+class ResolvedItem(BaseModel):
+    """A prior review finding the model judges to have been addressed in this update.
+
+    `path` and `line` are optional on purpose. They are what allows the corresponding GitHub
+    review thread to be resolved automatically, but a model that cannot confidently attribute a
+    resolved item to a specific location should omit them rather than guess: the item is still
+    reported in the summary, and its thread is simply left open. Leaving a thread open is a
+    small annoyance, whereas resolving the wrong one hides feedback that is still outstanding.
+    """
+
+    description: str = Field(description="What was resolved, in the requested language.")
+    path: str | None = Field(
+        default=None,
+        description=(
+            "Relative file path of the ORIGINAL comment being resolved. Provide this only when you are"
+            " certain which prior comment this refers to. Omit it if unsure."
+        ),
+    )
+    line: int | None = Field(
+        default=None,
+        description=(
+            "Line number the ORIGINAL comment was attached to, as shown in the prior review context."
+            " Provide only alongside path, and only when certain. Omit if unsure."
+        ),
+    )
+
+
 class ReviewResult(BaseModel):
     """Represents the structured review results returned by the Gemini model."""
 
     summary: str = Field(
         description="A brief, high-level assessment of the Pull Request's objective and quality (2-3 sentences)."
     )
-    resolved_items: list[str] = Field(
+    resolved_items: list[ResolvedItem] = Field(
         default_factory=list,
         description=(
-            "List of previously raised review comments/threads that have been resolved or addressed in this PR update."
+            "Previously raised review comments/threads that have been resolved or addressed in this PR update."
+            " Include path and line ONLY when you are certain which prior comment each refers to."
         ),
     )
+
+    @field_validator("resolved_items", mode="before")
+    @classmethod
+    def _accept_plain_strings(cls, value: object) -> object:
+        """Coerce a bare string into a ResolvedItem.
+
+        `resolved_items` used to be a list of strings. The schema sent to the model is now the
+        structured form only, which is the point — the model must supply path and line for a
+        thread to be resolvable. But a replayed, cached, or hand-built response using the old
+        shape should still render rather than raise, since the alternative is losing a review
+        that has already been paid for over a formatting detail.
+        """
+        if isinstance(value, list):
+            return [{"description": v} if isinstance(v, str) else v for v in value]
+        return value
+
     general_feedback: list[str] = Field(
         description="General feedback items, positive observations, or non-line-specific feedback."
     )

--- a/gemini_review/threads.py
+++ b/gemini_review/threads.py
@@ -17,8 +17,14 @@ no resolution at all:
 3. **Failure is non-fatal.** A review that is already posted must not be lost because a follow-up
    mutation failed, so every error here is a warning.
 
-GraphQL only: `resolveReviewThread` has no REST equivalent. `GITHUB_TOKEN` with `pull-requests:
-write` can call it, which the action already requires.
+GraphQL only: `resolveReviewThread` has no REST equivalent.
+
+**The default `GITHUB_TOKEN` cannot call it.** Verified against a live PR: `viewerCanResolve` comes
+back `false` and the mutation is refused with `FORBIDDEN — Resource not accessible by integration`,
+even with `pull-requests: write`. Resolving a thread needs a personal access token or a GitHub App
+installation token with write access to pull requests, supplied as `github_token`. With the default
+token this module resolves nothing and says so on stderr, rather than failing the job: the review
+has already been posted and is worth more than the convenience.
 """
 
 import sys
@@ -207,9 +213,13 @@ def resolve_addressed_threads(
             )
             continue
         if not thread.get("viewerCanResolve"):
+            # Verified against a live PR: the default GITHUB_TOKEN reports false here and the
+            # mutation is refused with FORBIDDEN, regardless of pull-requests: write. Naming the
+            # actual fix matters, because "add a permission" is the obvious wrong guess.
             print(
-                f"Thread resolution: skipping {key[0]}:{key[1]} — the token cannot resolve it "
-                "(needs pull-requests: write).",
+                f"Thread resolution: skipping {key[0]}:{key[1]} — this token cannot resolve review "
+                "threads. The default GITHUB_TOKEN never can; supply a PAT or GitHub App token as "
+                "github_token to use this feature.",
                 file=sys.stderr,
             )
             continue

--- a/gemini_review/threads.py
+++ b/gemini_review/threads.py
@@ -1,0 +1,245 @@
+"""
+Description: Resolving GitHub review threads the reviewer itself has declared addressed.
+
+The problem this solves: the action already recognises when a prior finding has been fixed and
+prints it under "Resolved Items from Prior Reviews", but it never touches the thread. With
+"Require conversation resolution before merging" enabled, the merge stays blocked on a finding the
+reviewer has already agreed is done, and a human has to click Resolve on the reviewer's behalf.
+
+Three safety rules, because resolving a thread hides feedback and a wrong resolution is worse than
+no resolution at all:
+
+1. **Only threads authored by this action.** A human reviewer's thread is never touched, no matter
+   what the model claims to have resolved. This is enforced against the thread's first comment
+   author, not against the model's opinion.
+2. **Only exact (path, line) matches.** The model supplies the location; nothing is inferred from
+   prose. An item without a location is reported and left alone.
+3. **Failure is non-fatal.** A review that is already posted must not be lost because a follow-up
+   mutation failed, so every error here is a warning.
+
+GraphQL only: `resolveReviewThread` has no REST equivalent. `GITHUB_TOKEN` with `pull-requests:
+write` can call it, which the action already requires.
+"""
+
+import sys
+from typing import Any
+
+import requests
+
+from gemini_review.config import DEFAULT_TIMEOUT
+
+GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
+
+# Bot logins that represent "this action". A review posted with the default GITHUB_TOKEN is
+# authored by github-actions[bot]; a PAT or GitHub App posts under its own name, which is why the
+# expected author is passed in rather than hardcoded.
+_THREADS_QUERY = """
+query($owner: String!, $name: String!, $pr: Int!, $cursor: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $pr) {
+      reviewThreads(first: 100, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          isResolved
+          isOutdated
+          viewerCanResolve
+          comments(first: 1) {
+            nodes {
+              path
+              line
+              originalLine
+              author { login }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+_RESOLVE_MUTATION = """
+mutation($threadId: ID!) {
+  resolveReviewThread(input: {threadId: $threadId}) {
+    thread { id isResolved }
+  }
+}
+"""
+
+
+def _graphql(headers: dict, query: str, variables: dict, timeout: int) -> dict[str, Any] | None:
+    """POST a GraphQL document, returning `data` or None. Never raises."""
+    try:
+        res = requests.post(
+            GITHUB_GRAPHQL_URL,
+            headers=headers,
+            json={"query": query, "variables": variables},
+            timeout=timeout,
+        )
+    except requests.RequestException as e:
+        print(f"Warning: GitHub GraphQL request failed: {e}", file=sys.stderr)
+        return None
+
+    if res.status_code != 200:
+        print(f"Warning: GitHub GraphQL returned {res.status_code}: {res.text[:300]}", file=sys.stderr)
+        return None
+
+    try:
+        payload = res.json()
+    except ValueError:
+        print("Warning: GitHub GraphQL returned a non-JSON body.", file=sys.stderr)
+        return None
+
+    # GraphQL reports errors in a 200 response, so status alone is not success.
+    if payload.get("errors"):
+        messages = "; ".join(str(e.get("message", e)) for e in payload["errors"])
+        print(f"Warning: GitHub GraphQL error: {messages}", file=sys.stderr)
+        return None
+
+    return payload.get("data")
+
+
+def fetch_review_threads(repository: str, pr_number: int, headers: dict, timeout: int = DEFAULT_TIMEOUT) -> list[dict]:
+    """Every review thread on the PR, following pagination. Empty list on any failure."""
+    try:
+        owner, name = repository.split("/", 1)
+    except ValueError:
+        print(f"Warning: cannot parse repository '{repository}'.", file=sys.stderr)
+        return []
+
+    threads: list[dict] = []
+    cursor = None
+    # Bounded rather than `while True`: a malformed pageInfo should not loop forever inside CI.
+    for _ in range(20):
+        data = _graphql(
+            headers,
+            _THREADS_QUERY,
+            {"owner": owner, "name": name, "pr": pr_number, "cursor": cursor},
+            timeout,
+        )
+        if not data:
+            return threads
+        try:
+            block = data["repository"]["pullRequest"]["reviewThreads"]
+        except (KeyError, TypeError):
+            return threads
+        threads.extend(block.get("nodes") or [])
+        page = block.get("pageInfo") or {}
+        if not page.get("hasNextPage"):
+            break
+        cursor = page.get("endCursor")
+    return threads
+
+
+def _thread_key(thread: dict) -> tuple[str, int] | None:
+    """(path, line) for a thread, or None when it cannot be located.
+
+    `originalLine` is preferred over `line`: `line` shifts as the file changes underneath the
+    comment and becomes null once the thread is outdated, whereas `originalLine` still points at
+    the position the finding was raised against. Matching on `line` would silently stop matching
+    exactly when the developer edits the file, which is the moment the item gets resolved.
+    """
+    comments = (thread.get("comments") or {}).get("nodes") or []
+    if not comments:
+        return None
+    first = comments[0]
+    path = first.get("path")
+    line = first.get("originalLine")
+    if line is None:
+        line = first.get("line")
+    if not path or line is None:
+        return None
+    return (path, int(line))
+
+
+def _authored_by(thread: dict, expected_logins: set[str]) -> bool:
+    comments = (thread.get("comments") or {}).get("nodes") or []
+    if not comments:
+        return False
+    author = (comments[0].get("author") or {}).get("login") or ""
+    return author.lower() in {login.lower() for login in expected_logins}
+
+
+def resolve_addressed_threads(
+    repository: str,
+    pr_number: int,
+    headers: dict,
+    resolved_items: list,
+    bot_logins: set[str],
+    timeout: int = DEFAULT_TIMEOUT,
+    dry_run: bool = False,
+) -> list[str]:
+    """Resolve threads matching `resolved_items`. Returns human-readable descriptions of what was resolved.
+
+    Only unresolved threads authored by `bot_logins` and matching an item's exact (path, line) are
+    touched. Everything else is left alone and explained on stderr, because a silent no-op here
+    looks identical to a bug.
+    """
+    located = [(i.path, int(i.line)) for i in resolved_items if getattr(i, "path", None) and getattr(i, "line", None)]
+    skipped = len(resolved_items) - len(located)
+    if skipped:
+        print(
+            f"Thread resolution: {skipped} resolved item(s) had no file/line attribution and were left open.",
+            file=sys.stderr,
+        )
+    if not located:
+        return []
+
+    threads = fetch_review_threads(repository, pr_number, headers, timeout)
+    if not threads:
+        print("Thread resolution: no review threads returned; nothing to resolve.", file=sys.stderr)
+        return []
+
+    wanted = set(located)
+    resolved: list[str] = []
+    for thread in threads:
+        if thread.get("isResolved"):
+            continue
+        key = _thread_key(thread)
+        if key is None or key not in wanted:
+            continue
+        if not _authored_by(thread, bot_logins):
+            # A human raised this. The model does not get to close it.
+            print(
+                f"Thread resolution: skipping {key[0]}:{key[1]} — the thread was not opened by this reviewer.",
+                file=sys.stderr,
+            )
+            continue
+        if not thread.get("viewerCanResolve"):
+            print(
+                f"Thread resolution: skipping {key[0]}:{key[1]} — the token cannot resolve it "
+                "(needs pull-requests: write).",
+                file=sys.stderr,
+            )
+            continue
+        if dry_run:
+            print(f"Thread resolution [dry run]: would resolve {key[0]}:{key[1]}.", file=sys.stderr)
+            resolved.append(f"{key[0]}:{key[1]}")
+            continue
+
+        data = _graphql(headers, _RESOLVE_MUTATION, {"threadId": thread["id"]}, timeout)
+        if data and (data.get("resolveReviewThread") or {}).get("thread", {}).get("isResolved"):
+            resolved.append(f"{key[0]}:{key[1]}")
+        else:
+            print(f"Warning: failed to resolve thread at {key[0]}:{key[1]}.", file=sys.stderr)
+
+    if resolved:
+        print(f"Thread resolution: resolved {len(resolved)} thread(s): {', '.join(resolved)}", file=sys.stderr)
+    return resolved
+
+
+def reviewer_logins() -> set[str]:
+    """Logins that count as "this action" when deciding whether a thread is ours to resolve.
+
+    With the default GITHUB_TOKEN the review is authored by `github-actions[bot]`. A PAT or a
+    GitHub App posts under its own name, so GEMINI_REVIEWER_LOGIN allows that to be declared
+    rather than guessed. Guessing wrong fails safe: no thread matches, nothing is resolved.
+    """
+    import os
+
+    logins = {"github-actions[bot]", "github-actions"}
+    extra = os.environ.get("GEMINI_REVIEWER_LOGIN", "").strip()
+    if extra:
+        logins.update(part.strip() for part in extra.split(",") if part.strip())
+    return logins

--- a/starter-examples/gemini-review.yml
+++ b/starter-examples/gemini-review.yml
@@ -44,6 +44,7 @@ jobs:
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # resolve_addressed_threads: 'true' # auto-resolve threads this review marks addressed
           gemini_model: 'gemini-3.7-flash'
           language: 'English (UK)'           # Optional (e.g. English (UK), French, Spanish)
           # persona: 'straight'                # Optional: straight (default), dazbo, palpatine, rick

--- a/tests/test_threads.py
+++ b/tests/test_threads.py
@@ -1,0 +1,191 @@
+"""Tests for resolving review threads the reviewer declared addressed.
+
+The risk being defended against is not "does it resolve", it is "does it resolve the WRONG
+thread". Hiding feedback that is still outstanding is worse than leaving every thread open, so
+most of these tests are about refusing to act.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from gemini_review.schemas import ResolvedItem, ReviewResult
+from gemini_review.threads import (
+    _thread_key,
+    fetch_review_threads,
+    resolve_addressed_threads,
+    reviewer_logins,
+)
+
+BOT = {"github-actions[bot]"}
+
+
+def thread(path="a.py", line=10, author="github-actions[bot]", resolved=False, can_resolve=True, tid="T1"):
+    return {
+        "id": tid,
+        "isResolved": resolved,
+        "isOutdated": False,
+        "viewerCanResolve": can_resolve,
+        "comments": {"nodes": [{"path": path, "line": line, "originalLine": line, "author": {"login": author}}]},
+    }
+
+
+def gql(threads, resolve_ok=True):
+    """A requests.post double returning threads, then a mutation result."""
+
+    def _post(url, headers=None, json=None, timeout=None):
+        res = MagicMock()
+        res.status_code = 200
+        if "reviewThreads" in json["query"]:
+            res.json.return_value = {
+                "data": {
+                    "repository": {
+                        "pullRequest": {
+                            "reviewThreads": {"pageInfo": {"hasNextPage": False, "endCursor": None}, "nodes": threads}
+                        }
+                    }
+                }
+            }
+        else:
+            res.json.return_value = {
+                "data": {"resolveReviewThread": {"thread": {"id": "T1", "isResolved": resolve_ok}}}
+            }
+        return res
+
+    return _post
+
+
+class TestRefusesToActWhenUnsure:
+    def test_an_item_without_a_location_resolves_nothing(self):
+        """Prose alone must never be matched against a thread."""
+        with patch("gemini_review.threads.requests.post") as post:
+            out = resolve_addressed_threads("o/r", 1, {}, [ResolvedItem(description="fixed the thing")], BOT)
+        assert out == []
+        post.assert_not_called()
+
+    def test_a_human_thread_is_never_resolved(self):
+        """The model does not get to close a person's review comment."""
+        with patch("gemini_review.threads.requests.post", side_effect=gql([thread(author="a-human")])):
+            out = resolve_addressed_threads("o/r", 1, {}, [ResolvedItem(description="x", path="a.py", line=10)], BOT)
+        assert out == []
+
+    def test_a_mismatched_line_resolves_nothing(self):
+        with patch("gemini_review.threads.requests.post", side_effect=gql([thread(line=10)])):
+            out = resolve_addressed_threads("o/r", 1, {}, [ResolvedItem(description="x", path="a.py", line=99)], BOT)
+        assert out == []
+
+    def test_a_mismatched_path_resolves_nothing(self):
+        with patch("gemini_review.threads.requests.post", side_effect=gql([thread(path="a.py")])):
+            out = resolve_addressed_threads("o/r", 1, {}, [ResolvedItem(description="x", path="b.py", line=10)], BOT)
+        assert out == []
+
+    def test_an_already_resolved_thread_is_skipped(self):
+        with patch("gemini_review.threads.requests.post", side_effect=gql([thread(resolved=True)])):
+            out = resolve_addressed_threads("o/r", 1, {}, [ResolvedItem(description="x", path="a.py", line=10)], BOT)
+        assert out == []
+
+    def test_a_thread_the_token_cannot_resolve_is_skipped(self):
+        with patch("gemini_review.threads.requests.post", side_effect=gql([thread(can_resolve=False)])):
+            out = resolve_addressed_threads("o/r", 1, {}, [ResolvedItem(description="x", path="a.py", line=10)], BOT)
+        assert out == []
+
+    def test_only_the_matching_thread_of_several_is_resolved(self):
+        threads = [thread(path="a.py", line=10, tid="T1"), thread(path="b.py", line=20, tid="T2")]
+        with patch("gemini_review.threads.requests.post", side_effect=gql(threads)):
+            out = resolve_addressed_threads("o/r", 1, {}, [ResolvedItem(description="x", path="a.py", line=10)], BOT)
+        assert out == ["a.py:10"]
+
+
+class TestHappyPath:
+    def test_a_matching_bot_thread_is_resolved(self):
+        with patch("gemini_review.threads.requests.post", side_effect=gql([thread()])):
+            out = resolve_addressed_threads("o/r", 1, {}, [ResolvedItem(description="x", path="a.py", line=10)], BOT)
+        assert out == ["a.py:10"]
+
+    def test_dry_run_reports_without_mutating(self):
+        calls = []
+
+        def _post(url, headers=None, json=None, timeout=None):
+            calls.append(json["query"])
+            return gql([thread()])(url, headers=headers, json=json, timeout=timeout)
+
+        with patch("gemini_review.threads.requests.post", side_effect=_post):
+            out = resolve_addressed_threads(
+                "o/r", 1, {}, [ResolvedItem(description="x", path="a.py", line=10)], BOT, dry_run=True
+            )
+        assert out == ["a.py:10"]
+        assert not any("resolveReviewThread" in q for q in calls), "dry run must not mutate"
+
+
+class TestFailuresAreNonFatal:
+    """The review is already posted by this point. Nothing here may raise."""
+
+    def test_a_graphql_error_payload_returns_empty(self):
+        res = MagicMock(status_code=200)
+        res.json.return_value = {"errors": [{"message": "nope"}]}
+        with patch("gemini_review.threads.requests.post", return_value=res):
+            assert (
+                resolve_addressed_threads("o/r", 1, {}, [ResolvedItem(description="x", path="a.py", line=1)], BOT) == []
+            )
+
+    def test_a_non_200_returns_empty(self):
+        res = MagicMock(status_code=403, text="forbidden")
+        with patch("gemini_review.threads.requests.post", return_value=res):
+            assert fetch_review_threads("o/r", 1, {}) == []
+
+    def test_a_network_exception_returns_empty(self):
+        import requests as rq
+
+        with patch("gemini_review.threads.requests.post", side_effect=rq.RequestException("boom")):
+            assert fetch_review_threads("o/r", 1, {}) == []
+
+    def test_a_malformed_repository_returns_empty(self):
+        assert fetch_review_threads("not-a-repo", 1, {}) == []
+
+    def test_a_failed_mutation_is_not_reported_as_resolved(self):
+        with patch("gemini_review.threads.requests.post", side_effect=gql([thread()], resolve_ok=False)):
+            out = resolve_addressed_threads("o/r", 1, {}, [ResolvedItem(description="x", path="a.py", line=10)], BOT)
+        assert out == []
+
+
+class TestThreadKey:
+    def test_original_line_wins_over_line(self):
+        """`line` moves as the file changes and goes null once outdated; originalLine does not."""
+        t = thread()
+        t["comments"]["nodes"][0]["line"] = 999
+        t["comments"]["nodes"][0]["originalLine"] = 10
+        assert _thread_key(t) == ("a.py", 10)
+
+    def test_falls_back_to_line_when_original_is_absent(self):
+        t = thread()
+        t["comments"]["nodes"][0]["originalLine"] = None
+        t["comments"]["nodes"][0]["line"] = 42
+        assert _thread_key(t) == ("a.py", 42)
+
+    def test_a_thread_with_no_comments_has_no_key(self):
+        assert _thread_key({"comments": {"nodes": []}}) is None
+
+
+class TestReviewerLogins:
+    def test_defaults_to_the_actions_bot(self):
+        assert "github-actions[bot]" in reviewer_logins()
+
+    def test_env_can_declare_an_app_or_pat_identity(self, monkeypatch):
+        monkeypatch.setenv("GEMINI_REVIEWER_LOGIN", "my-app[bot], other")
+        logins = reviewer_logins()
+        assert "my-app[bot]" in logins and "other" in logins
+
+
+class TestSchemaCompatibility:
+    def test_plain_strings_are_still_accepted(self):
+        """The old shape must not raise; it just cannot be resolved automatically."""
+        r = ReviewResult(summary="s", resolved_items=["fixed a thing"], general_feedback=[], comments=[])
+        assert r.resolved_items[0].description == "fixed a thing"
+        assert r.resolved_items[0].path is None
+
+    def test_structured_items_round_trip(self):
+        r = ReviewResult(
+            summary="s",
+            resolved_items=[{"description": "d", "path": "a.py", "line": 3}],
+            general_feedback=[],
+            comments=[],
+        )
+        assert (r.resolved_items[0].path, r.resolved_items[0].line) == ("a.py", 3)

--- a/tests/test_threads.py
+++ b/tests/test_threads.py
@@ -83,6 +83,9 @@ class TestRefusesToActWhenUnsure:
         assert out == []
 
     def test_a_thread_the_token_cannot_resolve_is_skipped(self):
+        """Not hypothetical: the default GITHUB_TOKEN reports viewerCanResolve=false on every
+        thread and its mutation is refused with FORBIDDEN, verified on a live PR. This guard is
+        what turns that into a clear message instead of an error."""
         with patch("gemini_review.threads.requests.post", side_effect=gql([thread(can_resolve=False)])):
             out = resolve_addressed_threads("o/r", 1, {}, [ResolvedItem(description="x", path="a.py", line=10)], BOT)
         assert out == []


### PR DESCRIPTION
Closes #40.

## The problem

The action already knows when a finding has been fixed — it prints it under **Resolved Items from Prior Reviews** and does not repeat the comment. But the thread is never touched, so with **Require conversation resolution before merging** enabled the merge stays blocked on a finding the reviewer itself has already agreed is done. Someone clicks Resolve by hand, every PR.

## The change

Opt-in, `resolve_addressed_threads: 'true'`, **default `false`** — closing a human-visible thread on someone's behalf is opinionated, so it should be a choice.

Matching is by **exact `(path, line)` supplied by the model**, never inferred from prose. That is the part of the issue you and I both flagged as the risk, so `resolved_items` becomes a list of `ResolvedItem`:

```python
class ResolvedItem(BaseModel):
    description: str
    path: str | None = None   # omit if unsure
    line: int | None = None   # omit if unsure
```

A model that cannot confidently attribute an item omits the location. The item is still reported; its thread is simply left open. **Leaving a thread open is an annoyance. Resolving the wrong one hides feedback that is still outstanding**, so the whole module is built to refuse when unsure.

## Three safety properties, each with tests

**Only threads this action opened.** A human reviewer's thread is never resolved, whatever the model claims — enforced against the thread's author, not the model's opinion. `GEMINI_REVIEWER_LOGIN` declares the identity when posting as a PAT or GitHub App; guessing wrong fails safe and resolves nothing.

**Matches on `originalLine`, not `line`.** `line` shifts as the file changes underneath the comment and goes null once the thread is outdated — so matching on it would stop working at exactly the moment the developer fixes the thing and the item becomes resolvable.

**Never fatal.** It runs *after* the review is posted, and every failure inside it is a warning. A review that has already been paid for is never lost to a follow-up API call. GraphQL errors arrive in a 200 response, so the payload is checked rather than the status code, and pagination is bounded rather than `while True`.

## Backward compatible

A `field_validator(mode="before")` coerces bare strings into `ResolvedItem`. The schema sent to the model is the structured form only — that is the point — but a replayed or cached response in the old shape still renders instead of raising. **The existing `test_post_review_with_resolved_items` passes unchanged**, which is the check that matters here.

## Tests

21 new, and most of them assert that it *declines* to act: no location, a human-authored thread, a mismatched path, a mismatched line, an already-resolved thread, a token that cannot resolve, a GraphQL error payload, a non-200, a network exception, a malformed repo string, a failed mutation. Plus a dry-run test asserting no mutation is sent.

**188 passing**, `ruff check` and `ruff format --check` clean.

## Verified on a live PR

An earlier version of this description said the GraphQL shapes came from the docs and were untested. **They have since been tested**, on a throwaway repo with a real `github-actions[bot]` thread, a human-authored thread, and *Require conversation resolution before merging* enabled.

| Check | Result |
|---|---|
| Unresolved threads + branch rule | merge `BLOCKED` |
| Author gate given a deliberately wrong login | **refused**, `RESOLVED: []`, both threads untouched |
| Human-authored thread | never touched by the feature |
| PAT resolves the bot thread | `isResolved: true` |
| All threads resolved | merge `CLEAN` |

**It found a real defect, in my own issue text rather than in the code.** I wrote in #40 that `GITHUB_TOKEN` with `pull-requests: write` could call `resolveReviewThread`. It cannot:

```
viewerCanResolve      false          # on every thread
resolveReviewThread   FORBIDDEN — Resource not accessible by integration
```

The permission was granted and made no difference; the same mutation with a PAT succeeded immediately. So it is a capability the Actions token lacks, not a missing permission — and the skip message originally shipped in this PR said *"needs pull-requests: write"*, which would have sent people at the one fix that cannot work. Code, input description and README now name the actual requirement.

The guard itself was already correct: it skipped and explained rather than erroring, so the behaviour never needed changing, only the explanation.

## Notes

- **No new token plumbing.** `github_token` is an existing input; using this feature means passing a PAT or GitHub App token into it rather than the default. Anyone not using the feature changes nothing, and anyone who enables it with the default token still gets their review posted plus one line on stderr saying nothing was resolved and why. It degrades, it does not fail.
- GraphQL only; `resolveReviewThread` has no REST equivalent.
- GraphQL reports the thread author as **`github-actions`** while `viewer.login` is **`github-actions[bot]`**. `reviewer_logins()` includes both — matching only one silently matches nothing, which is indistinguishable from the feature not working.
- README gains a short section and an inputs-table row; the starter workflow gains a commented line.
