### PR TITLE
feat(context): allow excluding comment authors from the prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ jobs:
           # persona: 'straight'                # Optional: straight (default), dazbo, palpatine, rick
           # timeout: '60'                     # Optional API timeout in seconds
           # include_comment_history: 'true'   # Optional: include prior PR comment history (default: true)
+          # exclude_comment_authors: 'claude[bot]' # Optional: keep another bot's comments out of the prompt
           # resolve_addressed_threads: 'false' # Optional: auto-resolve threads the review marks addressed (default: false)
           # skip_inline_suggestions: 'true'   # Optional: skip re-reviews on commits created via GitHub UI inline fixes (default: true)
 ```
@@ -380,6 +381,28 @@ jobs:
           language: 'English (UK)'           # Optional
 ```
 
+### Excluding another reviewer's comments
+
+Comment history exists so the reviewer does not re-raise its **own** feedback once you have addressed it. That is a good default.
+
+It becomes something else when a **second automated reviewer** posts on the same pull requests. Their comments are fetched too, in full, and handed to the model as prior discussion — so the review that follows can restate their conclusions rather than reach its own.
+
+Not hypothetical. On a repository running two AI reviewers, the other bot posted first every time. Its four findings measured ~4,273 tokens against the 4,519 tokens of comment history this action then loaded, so essentially all of them were in the prompt, including the exact fixes. The review that followed reported three of those four findings, on the same lines, and nothing the other reviewer had not already found.
+
+Three costs, only one of them obvious:
+
+- **The review looks independent while being derivative.** A second opinion that read the first opinion is not a second opinion.
+- **You pay for it**, as ordinary input, on every subsequent review of that PR.
+- **It is invisible.** Nothing in the posted review says a finding was already on the page.
+
+```yaml
+        with:
+          exclude_comment_authors: 'claude[bot]'
+```
+
+Excluded comments never reach the prompt and are not counted in the reported token usage. Matching is case-insensitive, and everyone else's comments — humans included — are untouched.
+
+
 ## Configuration
 
 ### Action Inputs
@@ -391,6 +414,7 @@ jobs:
 | `gemini_model` | The Gemini model version to target for code review and dynamic context selection. | No | `gemini-3.7-flash` |
 | `command` | The mode/command to run: `review` (for PR reviews) or `triage` (for issue triaging). | No | `review` |
 | `include_comment_history` | Whether to fetch prior inline review threads and conversation comments from GitHub. | No | `'true'` |
+| `exclude_comment_authors` | Comma-separated GitHub logins whose comments are kept out of the prompt, e.g. `claude[bot]`. Useful when a second automated reviewer posts on the same PRs — see [Excluding another reviewer's comments](#excluding-another-reviewers-comments). | No | `''` |
 | `resolve_addressed_threads` | Resolve the GitHub review threads for findings the action reports as addressed, so *Require conversation resolution before merging* stops blocking on feedback the reviewer has already agreed is done. Only threads opened by this action, and only where the model supplied an exact file and line, are resolved. | No | `'false'` |
 | `language` | The language to use for the review comments (e.g. `English (UK)`, `English (US)`, `French`, `Spanish`). | No | `English (UK)` |
 | `persona` | Reviewer persona overlay (`straight`, `dazbo`, `palpatine`, `rick`). | No | `straight` |

--- a/action.yml
+++ b/action.yml
@@ -62,6 +62,15 @@ inputs:
       (the mutation is refused with FORBIDDEN) and the action will say so and carry on.
     required: false
     default: 'false'
+  exclude_comment_authors:
+    description: >-
+      Comma-separated GitHub logins whose comments are kept OUT of the prompt, e.g.
+      `claude[bot],some-other-reviewer[bot]`. Comment history exists so the reviewer does not
+      re-raise its OWN addressed feedback; another automated reviewer's comments serve a
+      different purpose entirely, since they hand this model its conclusions. Excluded comments
+      never reach the prompt and are not counted in the reported tokens.
+    required: false
+    default: ''
   persona:
     description: 'Persona overlay for reviewer (straight, dazbo, palpatine, rick)'
     required: false
@@ -90,6 +99,7 @@ runs:
         GEMINI_MODEL: ${{ inputs.gemini_model }}
         GEMINI_LANGUAGE: ${{ inputs.language }}
         GEMINI_TIMEOUT: ${{ inputs.timeout }}
+        GEMINI_EXCLUDE_COMMENT_AUTHORS: ${{ inputs.exclude_comment_authors }}
         GEMINI_RESOLVE_ADDRESSED_THREADS: ${{ inputs.resolve_addressed_threads }}
         GEMINI_INCLUDE_COMMENT_HISTORY: ${{ inputs.include_comment_history }}
         GEMINI_PERSONA: ${{ inputs.persona }}

--- a/gemini_pr_review.py
+++ b/gemini_pr_review.py
@@ -60,6 +60,7 @@ from gemini_review import (
     load_skill_instructions,
     load_system_instruction,
     load_workspace_rules,
+    parse_excluded_authors,
     parse_skill_metadata,
     post_commit_status,
     post_review,
@@ -277,7 +278,10 @@ def main():
     if should_include_comments and not is_dry_run and repository and pr_number:
         print(f"Fetching prior PR comments for PR #{pr_number}...", file=sys.stderr)
         review_comments, issue_comments = get_pr_comments(repository, pr_number, headers, timeout=timeout)
-        comment_history_str = format_pr_comment_history(review_comments, issue_comments)
+        excluded_authors = parse_excluded_authors(os.environ.get("GEMINI_EXCLUDE_COMMENT_AUTHORS"))
+        if excluded_authors:
+            print(f"Comment history: excluding authors {sorted(excluded_authors)}.", file=sys.stderr)
+        comment_history_str = format_pr_comment_history(review_comments, issue_comments, excluded_authors)
         if comment_history_str:
             comment_history_tokens = count_text_tokens(client, model_name, comment_history_str)
             print(

--- a/gemini_review/__init__.py
+++ b/gemini_review/__init__.py
@@ -22,10 +22,12 @@ from .developer_knowledge import (
     search_google_developer_knowledge,
 )
 from .github import (
+    filter_comment_authors,
     format_pr_comment_history,
     get_pr_comments,
     get_pr_files,
     is_inline_suggestion_commit,
+    parse_excluded_authors,
     post_commit_status,
     post_review,
     post_with_retry,
@@ -107,6 +109,8 @@ __all__ = [
     "format_diff_patch_with_line_numbers",
     "format_file_content_with_line_numbers",
     "format_pr_comment_history",
+    "filter_comment_authors",
+    "parse_excluded_authors",
     "generate_file_tree",
     "get_all_repo_files",
     "get_file_content",

--- a/gemini_review/github.py
+++ b/gemini_review/github.py
@@ -93,8 +93,38 @@ def get_pr_comments(
     return review_comments, issue_comments
 
 
-def format_pr_comment_history(review_comments: list[dict], issue_comments: list[dict]) -> str:
-    """Format inline review comments into structured threads, and general issue comments into conversation history."""
+def parse_excluded_authors(raw: str | None) -> set[str]:
+    """Logins whose comments must not enter the prompt. Case-insensitive, comma-separated."""
+    if not raw:
+        return set()
+    return {part.strip().lower() for part in str(raw).split(",") if part.strip()}
+
+
+def _author_login(comment: dict) -> str:
+    return ((comment or {}).get("user") or {}).get("login") or ""
+
+
+def filter_comment_authors(comments: list[dict], excluded: set[str]) -> list[dict]:
+    """Drop comments written by an excluded author, keeping everything else untouched."""
+    if not excluded:
+        return comments
+    return [c for c in comments if isinstance(c, dict) and _author_login(c).lower() not in excluded]
+
+
+def format_pr_comment_history(
+    review_comments: list[dict],
+    issue_comments: list[dict],
+    exclude_authors: set[str] | None = None,
+) -> str:
+    """Format inline review comments into structured threads, and general issue comments into conversation history.
+
+    `exclude_authors` drops comments by the given logins before formatting, so excluded content
+    never reaches the prompt and never appears in the reported token count.
+    """
+    if exclude_authors:
+        review_comments = filter_comment_authors(review_comments, exclude_authors)
+        issue_comments = filter_comment_authors(issue_comments, exclude_authors)
+
     if not review_comments and not issue_comments:
         return ""
 

--- a/starter-examples/gemini-review.yml
+++ b/starter-examples/gemini-review.yml
@@ -50,4 +50,5 @@ jobs:
           # persona: 'straight'                # Optional: straight (default), dazbo, palpatine, rick
           # timeout: '60'                     # Optional API timeout in seconds
           # include_comment_history: 'true'   # Optional: include prior PR comment history (default: true)
+          # exclude_comment_authors: 'claude[bot]' # Optional: keep another bot's comments out of the prompt
           # skip_inline_suggestions: 'true'   # Optional: skip re-reviews on commits created via GitHub UI inline fixes (default: true)

--- a/tests/test_comment_authors.py
+++ b/tests/test_comment_authors.py
@@ -1,0 +1,75 @@
+"""Tests for keeping selected authors out of the prompt.
+
+The motivating case: another automated reviewer had already posted its full findings on the PR,
+and comment history ingested all of them verbatim. The review that followed reported three of
+that reviewer's four findings, on the same lines, and nothing it had not already found — which is
+indistinguishable from restating them. Comment history exists so a reviewer does not re-raise its
+OWN addressed feedback; a competing reviewer's comments are a different thing entirely.
+"""
+
+from gemini_review.github import (
+    filter_comment_authors,
+    format_pr_comment_history,
+    parse_excluded_authors,
+)
+
+
+def c(login, body="x", **kw):
+    d = {"user": {"login": login}, "body": body, "path": "a.py", "line": 1, "id": abs(hash((login, body))) % 10**6}
+    d.update(kw)
+    return d
+
+
+class TestParse:
+    def test_empty_is_no_exclusion(self):
+        assert parse_excluded_authors("") == set()
+        assert parse_excluded_authors(None) == set()
+
+    def test_comma_separated_and_trimmed(self):
+        assert parse_excluded_authors(" a[bot] , b ") == {"a[bot]", "b"}
+
+    def test_case_insensitive(self):
+        assert parse_excluded_authors("Claude[Bot]") == {"claude[bot]"}
+
+
+class TestFilter:
+    def test_excluded_author_is_dropped(self):
+        out = filter_comment_authors([c("claude[bot]"), c("alice")], {"claude[bot]"})
+        assert [x["user"]["login"] for x in out] == ["alice"]
+
+    def test_matching_ignores_case(self):
+        out = filter_comment_authors([c("Claude[Bot]")], {"claude[bot]"})
+        assert out == []
+
+    def test_no_exclusions_returns_input_untouched(self):
+        items = [c("a"), c("b")]
+        assert filter_comment_authors(items, set()) is items
+
+    def test_a_malformed_entry_does_not_raise(self):
+        assert filter_comment_authors([None, "junk", c("alice")], {"bob"})[0]["user"]["login"] == "alice"
+
+    def test_a_comment_with_no_author_is_kept(self):
+        """The filter excludes NAMED authors. An unattributable comment is not one of them, and
+        discarding it would silently lose legitimate content to defend against a malformed payload."""
+        assert filter_comment_authors([{"body": "orphan"}], {"bob"}) == [{"body": "orphan"}]
+
+
+class TestFormatting:
+    def test_excluded_content_never_reaches_the_prompt(self):
+        out = format_pr_comment_history([c("claude[bot]", "USE FieldValue.delete()")], [], {"claude[bot]"})
+        assert "FieldValue.delete" not in out
+
+    def test_everything_excluded_yields_an_empty_history(self):
+        """Empty rather than a bare header — an empty section still costs tokens and says nothing."""
+        assert format_pr_comment_history([c("claude[bot]")], [c("claude[bot]")], {"claude[bot]"}) == ""
+
+    def test_other_authors_survive(self):
+        out = format_pr_comment_history([c("alice", "please rename this")], [], {"claude[bot]"})
+        assert "please rename this" in out
+
+    def test_default_behaviour_is_unchanged(self):
+        """No exclusions configured must behave exactly as before."""
+        before = format_pr_comment_history([c("claude[bot]", "keep me")], [])
+        after = format_pr_comment_history([c("claude[bot]", "keep me")], [], set())
+        assert before == after
+        assert "keep me" in before


### PR DESCRIPTION
## The problem

`include_comment_history` exists so the reviewer does not re-raise its **own** feedback once it has been addressed. Good default, and not what this PR changes.

It becomes something else when a **second automated reviewer** runs on the same pull requests. `format_pr_comment_history` applies no author filter, so the other bot's comments are fetched in full and handed to the model as prior discussion — and the review that follows can restate their conclusions instead of reaching its own.

## Measured, not hypothetical

On a repository running two AI reviewers, the other bot posted first on **every** paired PR:

| | other reviewer | this action | gap |
|---|---|---|---|
| PR A | 11:38 | 14:16 | 2h38 |
| PR B | 12:54 | next day 08:37 | ~20h |
| PR C | 11:45 | 13:32 | 1h47 |

On PR C the log read `PR comment history included (4,519 tokens)`. The other reviewer's four comments measure **~4,273 tokens** — so essentially all of them, not a summary. The exact solution terms were in the prompt: the specific API call to fix the bug, the in-repo precedent to copy, the hardcoded hostname, the schema name.

This action then reported **three of that reviewer's four findings, on the same lines, and nothing it had not already found.** Whether that was discovery or restatement is not decidable from the output, which is the point.

## Three costs, one of them obvious

- **The review looks independent while being derivative.** A second opinion that read the first opinion is not a second opinion.
- **You pay for it**, as ordinary uncached input, on every subsequent review of that PR.
- **It is invisible.** Nothing in the posted review indicates a finding was already on the page.

## The change

```yaml
        with:
          exclude_comment_authors: 'claude[bot]'
```

Comma-separated logins, case-insensitive, **default empty so existing behaviour is unchanged**.

Filtering happens *before* formatting, so excluded comments never reach the prompt and are not counted in the reported token usage — otherwise the cost line would report tokens that were never sent.

A comment with no resolvable author is **kept**, not dropped. The filter excludes *named* authors; discarding unattributable content to guard against a malformed payload would silently lose legitimate comments.

## Tests

11 new, 200 total. Includes a test asserting that with no exclusions configured the output is byte-identical to before.

`ruff check` and `ruff format --check` clean.

## Note

I found this while trying to benchmark this action against another reviewer, so my motivation was benchmarking. But I think the behaviour is worth an escape hatch regardless: ingesting a competing reviewer's complete findings is surprising, and a maintainer of a repo with two bots would probably want to know it is happening even if they then choose to leave it on.