### PR TITLE
docs(starter): add job-level concurrency, and explain why the placement matters

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,13 +279,13 @@ Not in the examples, but a natural addition to avoid paying for three reviews wh
 jobs:
   review:
     concurrency:
-      group: gemini-review-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event_name }}
+      group: gemini-review-${{ github.event.pull_request.number || github.event.issue.number }}
       cancel-in-progress: true
 ```
 
-Workflow-level `concurrency` is evaluated when a run is **queued**, before any job `if` is evaluated. An `issue_comment` payload has no top-level `pull_request`, so a key like `${{ github.event.pull_request.number || github.event.issue.number }}` falls through to the issue number, which for a pull request is the same number. Both trigger types then share one group.
+**Job level, not workflow level.** Workflow-level `concurrency` is evaluated when a run is **queued**, before any job `if` is evaluated. An `issue_comment` payload has no top-level `pull_request`, so the key falls through to the issue number, which for a pull request is the same number. Both trigger types then share one group, and **any comment on the PR cancels a review that is still running**, before the job gets to check whether the comment was a `/gemini-review` command at all.
 
-The result is that **any comment on the PR cancels a review that is still running**, before the job gets to check whether the comment was a `/gemini-review` command at all. Keeping it at job level, and including `github.event_name` in the key, avoids both halves.
+**Key on the PR number alone.** An earlier version of this section suggested adding `${{ github.event_name }}` to the key. That is wrong, and it is wrong in the opposite direction: it splits `pull_request` and `issue_comment` into separate queues, so a `/gemini-review` comment runs *alongside* an in-flight push review rather than superseding it. Two reviews, two bills, duplicate comments on the same PR. One review per PR at a time, newest wins.
 
 ### Seeing It In Action
 

--- a/starter-examples/gemini-review.yml
+++ b/starter-examples/gemini-review.yml
@@ -24,6 +24,24 @@ jobs:
         contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
       )
     runs-on: ubuntu-latest
+
+    # Re-reviewing on every push is the point, but a burst of pushes should not mean a burst of
+    # reviews. Each one is a full billed call.
+    #
+    # This MUST sit on the job, not on the workflow. At workflow level the group is evaluated when
+    # the run is QUEUED, before any job `if` is considered, and an `issue_comment` payload has no
+    # top-level `pull_request` — so the key falls through to `github.event.issue.number`, which is
+    # the same number as the PR. Any comment on the PR would therefore land in the same group and
+    # `cancel-in-progress` would kill the review already in flight, before the job could skip
+    # itself. Down here, cancellation only happens once a job is actually going to run.
+    #
+    # Key on the PR number alone. Adding `github.event_name` splits `pull_request` and
+    # `issue_comment` into separate queues, so a `/gemini-review` comment would run alongside an
+    # in-flight push review instead of superseding it. One review per PR at a time, newest wins.
+    concurrency:
+      group: gemini-review-${{ github.event.pull_request.number || github.event.issue.number }}
+      cancel-in-progress: true
+
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Two changes, and the second is a correction to advice I added myself in #41.

## 1. The starter workflow has no concurrency control

It re-reviews on every push, which is the right default, but a burst of pushes means a burst of **full billed reviews**. Anyone copying the starter inherits that. Adds the block, on the job, with the reasoning inline.

```yaml
jobs:
  review:
    concurrency:
      group: gemini-review-${{ github.event.pull_request.number || github.event.issue.number }}
      cancel-in-progress: true
```

## 2. The README caveat I wrote in #41 is wrong

That section recommends adding `${{ github.event_name }}` to the key. **It is wrong, and wrong in the opposite direction to the bug it was guarding against.**

Including the event splits `pull_request` and `issue_comment` into separate queues, so a `/gemini-review` comment runs **alongside** an in-flight push review instead of superseding it. Two reviews, two bills, duplicate comments on the same PR.

The placement advice in that section was right; the key was not. Both halves are now stated together:

- **Job level, not workflow level** — at workflow level the group is evaluated when the run is *queued*, before any job `if`, and an `issue_comment` payload falls through to the issue number. Any comment on the PR then cancels a running review.
- **PR number alone in the key** — no event name.

## Provenance

Both found in production, in that order, on repos running this action. I hit the first, moved concurrency to job level, added `event_name` as belt and braces, and created the second.

The second was found by **this action reviewing its own workflow file** on one of our pull requests, which I enjoyed more than I should have.