### PR TITLE
feat(pricing): add Gemini 3.8 Flash

### DIFF
--- a/gemini_review/pricing.py
+++ b/gemini_review/pricing.py
@@ -54,6 +54,14 @@ class Rate:
 # Keys are matched after normalising the model id (see `_normalise`), so
 # "models/gemini-3.7-flash" and "publishers/google/models/gemini-3.7-flash" both resolve.
 RATES: dict[str, Rate] = {
+    "gemini-3.8-flash": Rate(
+        input=1.50,
+        output=7.50,
+        label="Gemini 3.8 Flash",
+        # Same introductory structure as 3.7: half price until the end of 2026.
+        promo=Promo(input=0.75, output=3.75, ends_after="2026-12-31"),
+        note="standard tier; batch and flex are half again, priority is higher",
+    ),
     "gemini-3.7-flash": Rate(
         input=1.50,
         output=7.50,

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -136,6 +136,19 @@ class TestUsd:
         assert usd(amount) == expected
 
 
+class TestGemini38Flash:
+    """3.8 shipped priced identically to 3.7, including the same promo end date."""
+
+    def test_it_is_priced_and_not_reported_as_unknown(self):
+        cost = estimate_cost(usage(fresh=1_000_000), "gemini-3.8-flash", today=date(2026, 8, 29))
+        assert cost.rate is not None, "an unpriced model reports tokens and no cost"
+        assert cost.total == pytest.approx(0.75)
+
+    def test_the_promo_expires_with_the_year(self):
+        after = estimate_cost(usage(fresh=1_000_000), "gemini-3.8-flash", today=date(2027, 1, 1))
+        assert after.total == pytest.approx(1.50)
+
+
 class TestRateTable:
     def test_every_promo_is_cheaper_than_its_standard_rate(self):
         """A promo dearer than the standard rate would mean the two were swapped."""


### PR DESCRIPTION
Gemini 3.8 Flash shipped today and is already usable on Vertex (verified with a live `generate_content` call).

Without a rate entry the pricing module does the right thing and reports **tokens with no cost** — which is exactly the wrong outcome for anyone switching to it. The review still works; the cost line quietly disappears, and nobody notices until someone asks what reviews cost.

## Pricing

Identical to 3.7 Flash: **$0.75 / $3.75 per 1M introductory through 2026-12-31**, then **$1.50 / $7.50**. Same promo structure, so the existing end-date handling applies unchanged and the reported figure stays correct on both sides of new year.

## Tests

Two: that it is priced rather than reported as unknown, and that the promo expires with the year. 202 passing, `ruff check` and `ruff format --check` clean.

Sources: [Gemini API pricing](https://ai.google.dev/gemini-api/docs/pricing) · [Agent Platform pricing](https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing)